### PR TITLE
chore: add redirecting demo.html

### DIFF
--- a/src/pages/demo.html
+++ b/src/pages/demo.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting...</title>
+<meta http-equiv="refresh" content="0; URL=https://calendly.com/eseidel/shorebird-demo">
+<link rel="canonical" href="https://calendly.com/eseidel/shorebird-demo">

--- a/src/pages/demo.html
+++ b/src/pages/demo.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>Redirecting...</title>
-<meta http-equiv="refresh" content="0; URL=https://calendly.com/eseidel/shorebird-demo">
-<link rel="canonical" href="https://calendly.com/eseidel/shorebird-demo">
+<meta
+  http-equiv="refresh"
+  content="0; URL=https://calendly.com/eseidel/shorebird-demo"
+/>
+<link rel="canonical" href="https://calendly.com/eseidel/shorebird-demo" />


### PR DESCRIPTION
Adds a demo.html page to make shorebird.dev/demo redirect to https://calendly.com/eseidel/shorebird-demo.