### PR TITLE
chore: move to use our discord vanity url everywhere

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -31,7 +31,7 @@ const faqs = [
   {
     question: 'Can I use this in production?',
     answer:
-      'Yes!  Shorebird is used in production today. If you have any concerns we are happy to meet with you and/or discuss your concerns live [on Discord](https://discord.gg/9hKJcWGcaB).',
+      'Yes!  Shorebird is used in production today. If you have any concerns we are happy to meet with you and/or discuss your concerns live [on Discord]({config.discordUrl}).',
   },
   {
     question: 'Are there any limitations or known issues?',
@@ -90,7 +90,7 @@ export const FAQ = () => (
               <a
                 target="_blank"
                 className="underline"
-                href="https://discord.gg/shorebird"
+                href="{config.discordUrl}"
               >
                 ask us on Discord.
               </a>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 export const config = {
   app: 'Shorebird',
-  discordUrl: 'https://discord.gg/9hKJcWGcaB',
+  discordUrl: 'https://discord.gg/shorebird',
   githubUrl: 'https://github.com/shorebirdtech/shorebird',
   twitterUrl: 'https://twitter.com/shorebirddev',
   docsUrl: 'https://docs.shorebird.dev',


### PR DESCRIPTION
Fix a few more places mentioning our direct invite link instead of our "vanity url"