### PR TITLE
chore: redirect /terms.html to /terms

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,4 +6,9 @@ import tailwind from '@astrojs/tailwind';
 export default defineConfig({
   site: 'https://shorebird.dev',
   integrations: [react(), tailwind()],
+  redirects: {
+    // Some old docs may still point to .html urls for terms and privacy.
+    '/terms.html': '/terms',
+    '/privacy.html': '/privacy',
+  }
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,5 +10,5 @@ export default defineConfig({
     // Some old docs may still point to .html urls for terms and privacy.
     '/terms.html': '/terms',
     '/privacy.html': '/privacy',
-  }
+  },
 });


### PR DESCRIPTION
Before we used Astro we had .html suffixes on all our routes,
now we don't, but some docs (including /terms itself) still points
to /terms.html.  I don't want to modify /terms.html itself so
I'm adding the redirect.  We can update the url in /terms
next time we modify the Terms.