### PR TITLE
feat: move "docs" button to the end of the navigation

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,12 +22,12 @@ const links = [
   { label: 'Pricing', href: '#pricing', ariaLabel: 'Pricing' },
   { label: 'Team', href: '#team', ariaLabel: 'Team' },
   { label: 'Newsletter', href: '#newsletter', ariaLabel: 'Newsletter' },
+  { label: 'FAQ', href: '#faq', ariaLabel: 'FAQ' },
   {
     label: 'Docs',
     href: 'https://docs.shorebird.dev',
     ariaLabel: 'Documentation',
   },
-  { label: 'FAQ', href: '#faq', ariaLabel: 'FAQ' },
 ];
 ---
 


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Tiny nit: This PR moves the "docs" button to the end of the navigation bar to be consistent in showing all buttons that just scroll to the section within the page first, and the buttons that exit the page.

Before this pull request:

* Home -> scrolls to section
* Products -> scrolls to section
* Pricing -> scrolls to section
* Team -> scrolls to section
* Newsletter -> scrolls to section
* Docs -> redirects to a new page
* FAQ -> scrolls to section

After this pull request:

* Home -> scrolls to section
* Products -> scrolls to section
* Pricing -> scrolls to section
* Team -> scrolls to section
* Newsletter -> scrolls to section
* FAQ -> scrolls to section
* Docs -> redirects to a new page

Please don't hesitate to close this PR if don't agree with it. Also I don't if there were some reasons to not place the "docs" button at the end. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
