### PR TITLE
docs: Update Shorebird TOS for 2024

### DIFF
--- a/src/pages/terms/index.md
+++ b/src/pages/terms/index.md
@@ -2,12 +2,12 @@
 layout: ../../layouts/MarkdownLayout.astro
 title: Terms of Use
 description: Shorebird Terms of Use
-last_updated: 02-22-2023
+last_updated: 02-29-2024
 ---
 
 # Terms of Service
 
-Last updated and Effective as of February 26, 2024.
+Last updated and Effective as of February 29, 2024.
 
 THESE TERMS OF SERVICE (“TERMS OF SERVICE” OR “AGREEMENT”) GOVERN YOUR USE OF
 THE SHOREBIRD.DEV WEBSITE AND/OR ANY OF THE SERVICES OFFERED BY CODE TOWN, INC.

--- a/src/pages/terms/index.md
+++ b/src/pages/terms/index.md
@@ -80,7 +80,7 @@ VERSION OF THE PRODUCTS.
 - You must be a human. Accounts registered by “bots” or other automated methods
   are not permitted.
 - You must provide your name, a valid email address, and any other information
-  requested in order to complete the signup process for Your Account. All such
+  requested in order to complete the sign-up process for Your Account. All such
   information shall be accurate and complete.
 - Your login may only be used by one person - a single login shared by multiple
   people is not permitted.
@@ -103,7 +103,7 @@ display the Application and/or User Data solely for the purposes of providing
 the Services. You further agree Shorebird has the perpetual license and right to
 copy, analyze and use any of Your User Data solely in anonymized and aggregated
 format for Shorebird’s business purposes. For the avoidance of doubt,
-Shorebird will not; (i) reverse engineer, decompile, translate, disassemble, or
+Shorebird will not; (i) reverse engineer, de-compile, translate, disassemble, or
 attempt to discover the source code of any Application or any part thereof; or
 (ii) distribute the Application or any part thereof to any third party other
 than solely as part of providing the Services. Shorebird does not pre-screen
@@ -115,7 +115,7 @@ available via the Services.
 
 Shorebird hereby grant to You, solely during the applicable term of Your use of
 the Services, a royalty free, limited, personal, non-exclusive,
-non-transferable, non-sublicensable license to: (i) access (via the Internet
+non-transferable, non-sub-licensable license to: (i) access (via the Internet
 address provided to You by Shorebird), download, install and use the Services;
 (ii) build and distribute to Your applications built with the Services (but
 without including or distributing the Services or any part thereof); and (iii)

--- a/src/pages/terms/index.md
+++ b/src/pages/terms/index.md
@@ -2,219 +2,312 @@
 layout: ../../layouts/MarkdownLayout.astro
 title: Terms of Use
 description: Shorebird Terms of Use
-last_updated: 03-21-2023
+last_updated: 02-22-2023
 ---
 
 # Terms of Service
 
-_Last updated March 21th, 2023._
+Last updated and Effective as of February 26, 2024.
 
-By using the shorebird.dev website ("Service"), or any services of Code Town,
-Inc("Shorebird"), you are agreeing to be bound by the following terms and
-conditions ("Terms of Service"). IF YOU ARE ENTERING INTO THIS AGREEMENT ON
-BEHALF OF A COMPANY OR OTHER LEGAL ENTITY, YOU REPRESENT THAT YOU HAVE THE
-AUTHORITY TO BIND SUCH ENTITY, ITS AFFILIATES AND ALL USERS WHO ACCESS OUR
-SERVICES THROUGH YOUR ACCOUNT TO THESE TERMS AND CONDITIONS, IN WHICH CASE THE
-TERMS "YOU" OR "YOUR" SHALL REFER TO SUCH ENTITY, ITS AFFILIATES AND USERS
-ASSOCIATED WITH IT. IF YOU DO NOT HAVE SUCH AUTHORITY, OR IF YOU DO NOT AGREE
-WITH THESE TERMS AND CONDITIONS, YOU MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT
-USE THE SERVICES.
+THESE TERMS OF SERVICE (“TERMS OF SERVICE” OR “AGREEMENT”) GOVERN YOUR USE OF
+THE SHOREBIRD.DEV WEBSITE AND/OR ANY OF THE SERVICES OFFERED BY CODE TOWN, INC.
+(D/B/A “SHOREBIRD”) (COLLECTIVELY, THE “SERVICES”). IN THESE TERMS OF SERVICE,
+SHOREBIRD MAY BE REFERRED TO AS “SHOREBIRD” OR “US”, “OUR” OR “WE”. BY
+ACCESSING, USING, SUBSCRIBING, PURCHASING, OR DOWNLOADING ANY OF THE SERVICES,
+YOU SIGNIFY THAT YOU HAVE READ, UNDERSTOOD, AND AGREE TO BE BOUND BY THESE TERMS
+OF SERVICE ON BEHALF OF YOURSELF AND/OR ON BEHALF OF THE ACCOUNT OWNER (REFERRED
+TO HEREIN AS “ACCOUNT OWNER”, “YOU”, OR “YOUR”). YOU AGREE TO AND WILL ENSURE
+THAT ALL WHO ACCESS THE SERVICE THROUGH YOUR ACCOUNT, FOLLOW AND BE BOUND BY
+THESE TERMS OF SERVICE. THESE TERMS OF SERVICE WILL APPLY TO YOUR USE OF THE
+SERVICES, WHETHER OR NOT YOU ARE A REGISTERED USER OF OUR SERVICES.
 
-If Shorebird makes material changes to these Terms, we will notify you by email
-or by posting a notice on our site before the changes are effective. Any new
-features that augment or enhance the current Service, including the release of
-new tools and resources, shall be subject to the Terms of Service. Continued use
-of the Service after any such changes shall constitute your consent to such
-changes. You can review the most current version of the Terms of Service at any
-time at: https://shorebird.dev/terms.html.
+IF YOU ARE ENTERING INTO THIS AGREEMENT ON BEHALF OF A COMPANY OR OTHER LEGAL
+ENTITY, YOU REPRESENT THAT YOU HAVE THE AUTHORITY TO BIND SUCH ENTITY, ITS
+AFFILIATES AND ALL USERS WHO ACCESS OUR SERVICES THROUGH YOUR ACCOUNT TO THESE
+TERMS OF SERVICE, IN WHICH CASE THE TERMS “YOU” OR “YOUR” SHALL REFER TO SUCH
+ENTITY, ITS AFFILIATES AND USERS ASSOCIATED WITH IT. IF YOU DO NOT HAVE SUCH
+AUTHORITY, OR IF YOU DO NOT AGREE WITH THESE TERMS OF SERVICE, YOU MUST NOT
+ACCEPT THIS AGREEMENT AND MAY NOT USE THE SERVICES.
 
-Violation of any of the terms below will result in the termination of your
-Account. While Shorebird prohibits such conduct and Content on the Service, you
-understand and agree that Shorebird cannot be responsible for the Content posted
-on the Service and you nonetheless may be exposed to such materials. You agree
-to use the Service at your own risk.
+If Shorebird makes material changes to these Terms of Service, We will notify
+You by email or by posting a notice on Our site before the changes are
+effective. Any new features that augment or enhance the current Service(s),
+including the release of new tools and resources, shall be subject to these
+Terms of Service. Continued use of any of the Services after any such changes
+shall constitute your consent to such changes. You can review the most current
+version of the Terms of Service at any time at: https://shorebird.dev/terms.
 
-### 0. Beta Version
+## A. Certain Definitions.
 
-PLEASE NOTE THAT THE PRODUCTS ARE CURRENTLY BEING PROVIDED IN THEIR BETA
+- “Account” means an account through which You will access the Service(s) (to
+  the extent registration for an Account is required by Shorebird.
+- “Account Owner” means the individual who establishes the Account (through the
+  registration process provided by Us) and any other entity and/or person in
+  whose name the Account is established, all of whom are agreed to be jointly
+  and severally obligated under these Terms of Service.
+- “Application” means Your software program developed for use on multiple
+  platforms, including mobile, web, and/or desktop and which are uploaded by You
+  in connection with the Services.
+- “Intellectual Property Rights” means all patent rights, copyright rights, mask
+  work rights, moral rights, rights of publicity, trademark, trade dress and
+  service mark rights, goodwill, trade secret rights and other intellectual
+  property rights as may now exist or hereafter come into existence, and all
+  applications therefore and registrations, renewals and extensions thereof,
+  under the laws of any state, country, territory or other jurisdiction.
+- “Usage Data” means any information, content, data, comments, feedback
+  (including, without limitation, schema and other implementation details,
+  telemetry, IP and Geo-location data and service usage data) generated through
+  Your use of the Services.
+- “User Data” means all information, data or content owned by You and provided
+  to Us by You in connection with Your use of the Services. User Data will not
+  include any Application(s).
+
+## B. Beta Version
+
+PLEASE NOTE THAT THE SERVICES ARE CURRENTLY BEING PROVIDED IN THEIR BETA
 VERSIONS, THE FEATURES OF WHICH HAVE NOT BEEN FULLY IMPLEMENTED OR REFINED. AS
-WITH ANY BETA VERSION, THE PRODUCTS CURRENTLY CONSTITUTE A WORK IN PROGRESS AND
+WITH ANY BETA VERSION, THE SERVICES CURRENTLY CONSTITUTE A WORK IN PROGRESS AND
 AS SUCH, THERE MAY BE UNRESOLVED ISSUES. UNLESS YOU ARE COMFORTABLE USING BETA
 SOFTWARE AND UNDERSTAND THE IMPLICATIONS THEREOF, PLEASE DO NOT TO USE THIS BETA
-VERSION OF THE PRODUCTS
+VERSION OF THE PRODUCTS.
 
-### A. Account Terms
+## C. Account Registration
 
-- You must be 16 years or older to use this Service. If you are under 16 years
+- You must be 18 years or older to use this Service. If you are under 18 years
   of age, you must have explicit consent from your parent or legal guardian in
   order to use this Service, including consent to use elements of this Service
   which collect data to make delivery of this Service possible.
-- You must be a human. Accounts registered by "bots" or other automated methods
+- You must be a human. Accounts registered by “bots” or other automated methods
   are not permitted.
 - You must provide your name, a valid email address, and any other information
-  requested in order to complete the signup process.
+  requested in order to complete the signup process for Your Account. All such
+  information shall be accurate and complete.
 - Your login may only be used by one person - a single login shared by multiple
   people is not permitted.
-- You are responsible for maintaining the security of your account and password.
-  Shorebird cannot and will not be liable for any loss or damage from your failure
-  to comply with this security obligation.
-- You are responsible for all Content posted and activity that occurs under your
-  account (even when Content is posted by others who have accounts under your
-  account).
-- One person or legal entity may not maintain more than one free account.
-- You may not use the Service for any illegal or unauthorized purpose. You must
-  not, in the use of the Service, violate any laws in your jurisdiction (including
-  but not limited to copyright or trademark laws).
+- You are responsible for maintaining the security of Your account and password.
+  Shorebird cannot and will not be liable for any loss or damage from your
+  failure to comply with this security obligation.
 
-### B. API Terms
+## D. Application and User Data
 
-Customers may access their Shorebird account data via an API (Application
-Program Interface). Any use of the API, including use of the API through a
-third-party product that accesses Shorebird, is bound by these Terms of Service
-plus the following specific terms:
+In connection with Your Application and/or User Data, You affirm, represent, and
+warrant that You own or have all necessary Intellectual Property Rights,
+licenses, consents, and permissions to use and authorize Us to use, retain,
+copy, and process the Application and/or User Data through the Services and as
+contemplated by this Agreement. You agree that by uploading, submitting or
+making any Application and/or User Data available to or through use of the
+Service, You hereby automatically at such time grant Shorebird, and it
+affiliates, for the duration of Your use of the Services, a non-exclusive,
+worldwide, royalty-free, license to use, reproduce, distribute, perform and
+display the Application and/or User Data solely for the purposes of providing
+the Services. You further agree Shorebird has the perpetual license and right to
+copy, analyze and use any of Your User Data solely in anonymized and aggregated
+format for Shorebird’s business purposes. For the avoidance of doubt,
+Shorebird will not; (i) reverse engineer, decompile, translate, disassemble, or
+attempt to discover the source code of any Application or any part thereof; or
+(ii) distribute the Application or any part thereof to any third party other
+than solely as part of providing the Services. Shorebird does not pre-screen
+User Data, but Shorebird and its designee have the right (but not the
+obligation) in their sole discretion to refuse or remove any User Data that is
+available via the Services.
 
-- You expressly understand and agree that Shorebird shall not be liable for any
-  direct, indirect, incidental, special, consequential or exemplary damages,
-  including but not limited to, damages for loss of profits, goodwill, use, data
-  or other intangible losses (even if Shorebird has been advised of the
-  possibility of such damages), resulting from your use of the API or third-party
-  products that access data via the API.
-- Abuse or excessively frequent requests to Shorebird via the API may result in
-  the temporary or permanent suspension of your account's access to the API.
-  Shorebird, in its sole discretion, will determine abuse or excessive usage of
-  the API. Shorebird will make a reasonable attempt via email to warn the account
-  owner prior to suspension.
-- Shorebird reserves the right at any time to modify or discontinue, temporarily
-  or permanently, your access to the API (or any part thereof) with or without
-  notice.
+## E. License Grant and Restrictions While Using the Services.
 
-### C. Deletion, Cancellation, and Termination
+Shorebird hereby grant to You, solely during the applicable term of Your use of
+the Services, a royalty free, limited, personal, non-exclusive,
+non-transferable, non-sublicensable license to: (i) access (via the Internet
+address provided to You by Shorebird), download, install and use the Services;
+(ii) build and distribute to Your applications built with the Services (but
+without including or distributing the Services or any part thereof); and (iii)
+use the Documentation, training materials or other materials supplied by
+Shorebird to enable such licensed rights.
 
-- All of your Content will be immediately deleted from the Service upon account
-  deletion. This information can not be recovered once your account is deleted.
+You agree that You will not:
 
-- Upon cancellation of any paid services you may lose access to any or all
-  related features and services. This does not affect the Content in your account.
+- Post, display or transmit information, data, Application(s) or User Data,
+  including the unauthorized use of any payment method, that violates any law,
+  regulation or rule, or the rights of any third party including without
+  limitation Intellectual Property Rights;
+- Post or transmit viruses, Trojan horses, worms, spyware, time bombs,
+  cancelbots, or other computer programming routines that may harm the Services
+  or interests or rights of other users, or that may harvest or collect any data
+  or personally identifiable information about other users without their
+  consent;
+- Post or transmit any information, data, Application(s) or User Data that is
+  unlawful, harmful, abusive, racially or ethnically offensive, defamatory,
+  infringing, invasive of personal privacy or publicity rights, harassing,
+  humiliating to other people (publicly or otherwise), libelous, threatening, or
+  otherwise objectionable;
+- Use or launch any automated system, including without limitation, “robots,”
+  “spiders,” “offline readers,” etc., that accesses the Services in a manner
+  that sends more request messages to the Shorebird servers than a human can
+  reasonably produce in the same period of time by using a conventional on-line
+  web browser; or
+- Attempt to gain unauthorized access to any other party’s Account, password,
+  Application or User Data, or allow more than one person to use an Account.
+- Use the Services in any manner that would violate the terms of use of any
+  applicable third-party.
 
-- Shorebird, in its sole discretion, has the right to suspend or terminate your
-  account and refuse any and all current or future use of the Service, or any
-  other Shorebird service, for any reason at any time. Such termination of the
-  Service will result in the deactivation or deletion of your Account or your
-  access to your Account, and the forfeiture and relinquishment of all Content in
-  your Account. Shorebird reserves the right to refuse service to anyone for any
-  reason at any time. In the event that Shorebird takes action to suspend or
-  terminate an account, we will make a reasonable effort to provide the affected
-  account owner with a copy of their account contents upon request, unless the
-  account was suspended or terminated due to unlawful conduct.
+## F. Fees and Billing
 
-### D. Modifications to the Service and Prices
+We provide the Services for the fees, if any, and other charges set forth in our
+pricing section here https://shorebird.dev/pricing. All prices listed exclude
+all sales taxes, fees, use taxes (including, without limitation, value-added or
+withholding taxes), charges, duties, levies and similar governmental charges
+(“Sales Taxes”) imposed on the provision of the Services and all such Sales
+Taxes shall be borne solely by and paid by You to Us and deemed to be in
+addition to the fees charged in connection with the Services. You acknowledge
+that it is Your responsibility to ensure payment in advance for all paid aspects
+of the Services, and to ensure that your credit or debit cards or other payment
+instruments accepted by Us and/or Our processor, including Stripe, continue to
+be valid and sufficient for such purposes. We may suspend or terminate Your use
+and Your Account’s use in the event of any payment delinquency. You will not be
+entitled to any refund on termination or expiration of the Agreement or any
+refund for the partial use of the Services or credits at any time. All fees paid
+are non-refundable. In the event of any termination or expiration of the
+Agreement, you will remain liable for any charges incurred or unpaid amounts
+owed by You to Us.
+
+In order to use payment processing services and the billing services, You may
+have to agree to certain terms from our third-party payment processor(s) and
+Your use of the Services will be dependent on You agreeing to such terms, if
+any. You also acknowledge and agree that while You are using the Services
+through an Account, we will bill you automatically for the applicable fees, on a
+monthly basis, in advance.
+
+## G. Term and Termination.
+
+This Agreement shall remain in full force and effect while you use the Services.
+You may terminate the Services at any time by providing notice to Shorebird.
+Shorebird may permanently or temporarily terminate, suspend, or otherwise refuse
+to permit your access to the Services without notice and liability, if, in Our
+sole determination, You violate any of terms of this Agreement, including, but
+not limited to, the following prohibited actions: (i) attempting to interfere
+with, compromise the system integrity or security or decipher any transmissions
+to or from the servers running the Services; (ii) taking any action that
+imposes, or may impose at our sole discretion an unreasonable or
+disproportionately large load on our infrastructure; (iii) uploading invalid
+data, viruses, worms, or other software agents through the Service; (iv)
+impersonating another person or otherwise misrepresenting your affiliation with
+a person or entity, conducting fraud, hiding or attempting to hide your
+identity; (v) interfering with the proper working of the Service; or (vi)
+bypassing the measures we may use to prevent or restrict access to the Services,
+including, but not limited to, registering for the Services with an email
+address that is not rightfully yours.
+
+Upon termination of this Agreement or Your Account and hence the Services, all
+licenses granted by Us and rights to use the Services, will automatically
+terminate, and any Applications and all User Data in Your Account will be
+immediately deleted as of the date of termination or expiration of Your Account
+or this Agreement. You are responsible for requesting from Us the retrieval of
+any Applications and all User Data as You require or is required by law by
+contacting [contact@shorebird.dev] prior to the Account termination date. The
+following terms will survive any termination of this Agreement: Sections I, J,
+K, L and M.
+
+## H. Modifications to the Service and Prices
 
 - Shorebird reserves the right at any time and from time to time to modify or
-  discontinue, temporarily or permanently, the Service (or any part thereof) with
-  or without notice.
+  discontinue, temporarily or permanently, the Service (or any part thereof)
+  with or without notice.
 - Shorebird shall not be liable to you or to any third-party for any
   modification, price change, suspension or discontinuance of the Service.
 
-### E. Copyright and Content Ownership
+## I. Proprietary Rights.
 
-- We claim no intellectual property rights over the material you provide to the
-  Service.
-- Shorebird does not pre-screen Content, but Shorebird and its designee have the
-  right (but not the obligation) in their sole discretion to refuse or remove any
-  Content that is available via the Service.
-- You shall defend Shorebird against any claim, demand, suit or proceeding made
-  or brought against Shorebird by a third-party alleging that Your Content, or
-  Your use of the Service in violation of this Agreement, infringes or
-  misappropriates the intellectual property rights of a third-party or violates
-  applicable law, and shall indemnify Shorebird for any damages finally awarded
-  against, and for reasonable attorney’s fees incurred by, Shorebird in connection
-  with any such claim, demand, suit or proceeding; provided, that Shorebird (a)
-  promptly gives You written notice of the claim, demand, suit or proceeding; (b)
-  gives You sole control of the defense and settlement of the claim, demand, suit
-  or proceeding (provided that You may not settle any claim, demand, suit or
-  proceeding unless the settlement unconditionally releases Shorebird of all
-  liability); and (c) provides to You all reasonable assistance, at Your expense.
-- The look and feel of the Service is copyright ©2023-present Code Town, Inc.
-  All rights reserved. You may not duplicate, copy, or reuse any portion of the
-  Shorebird mobile applications without express written permission from Shorebird.
-  The Shorebird command-line interface is open-sourced under the MIT or Apache 2.0
-  license at your choice.
+- _Services._ Except for your Application and User Data, the Services, and its
+  materials, including, without limitation, software, images, text, graphics,
+  illustrations, logos, patents, trademarks, service marks, copyrights,
+  photographs, audio, videos and music and the Usage Data (the “Content”), and
+  all Intellectual Property Rights related thereto, are the exclusive property
+  of Shorebird and its licensors. Except as explicitly provided herein, nothing
+  in this Agreement shall be deemed to create a license in or under any such
+  Intellectual Property Rights, and You agree not to sell, license, rent,
+  modify, distribute, copy, reproduce, transmit, publicly display, publicly
+  perform, publish, adapt, edit or create derivative works from any materials or
+  content accessible on the Service. Use of the Content, User Data or materials
+  on the Services for any purpose not expressly permitted by this Agreement is
+  strictly prohibited. You retain sole ownership of the Application and the User
+  Data.
+- _Ideas and Comments._ You may choose to, or We may invite You to submit
+  comments or ideas about the Services, including without limitation about how
+  to improve the Services or our products (“Ideas”). By submitting any Idea, You
+  agree that Your disclosure is gratuitous, unsolicited and without restriction
+  and will not place Shorebird under any fiduciary or other obligation, that We
+  are free to disclose the Ideas on a non-confidential basis to anyone or
+  otherwise use the Ideas without any additional compensation to You. You
+  acknowledge that, by acceptance of your submission, Shorebird does not waive
+  any rights to use similar or related ideas previously known to Shorebird, or
+  developed by its employees or contractors, or obtained from sources other than
+  you.
 
-### F. Refund Policy
+## J. Indemnity.
 
-- If you feel you are being billed in error, we strongly encourage you to
-  request a refund from your account or contact us rather than filing a dispute
-  with your credit card company. If a dispute is filed before you get in touch
-  with us, we are limited in what we can do to resolve it.
-- Credit card disputes are flagged to us by your provider as potentially
-  fraudulent so given the seriousness, if a credit card dispute is made, your
-  account may be suspended while we investigate and we ask you to contact us to
-  reinstate it.
-- To request a refund, please log in to your account and go to
-  Settings/Receipts.
-- If you do not have an account, please email our Developer Success team
-  directly at billing@shorebird.dev.
-- You will be asked to provide the reason for your request.
-- We aim to respond to refund requests within 5 business days of receipt.
+You agree to defend, indemnify and hold harmless Shorebird and its affiliates,
+agents, employees, contractors, agents, officers and directors of each, from and
+against any and all claims, damages, obligations, losses, liabilities, costs or
+debt, and expenses (including but not limited to attorney's fees) arising from:
+(i) Your use of and access to the Services; or (ii) Your violation of any terms
+of this Agreement.
 
-### G. General Conditions
+## K. No Warranty.
 
-- Your use of the Service is at your sole risk. The service is provided on an
-  "as is" and "as available" basis. Support for Shorebird services is only
-  available in English, via email.
-- You understand that Shorebird uses third-party vendors and hosting partners to
-  provide the necessary hardware, software, networking, storage, and related
-  technology required to run the Service.
-- You must not modify, adapt or hack the Service or modify another website so as
-  to falsely imply that it is associated with the Service, Shorebird, or any other
-  Shorebird service.
-- You agree not to reproduce, duplicate, copy, sell, resell or exploit any
-  portion of the Service, use of the Service, or access to the Service without the
-  express written permission by Shorebird.
-- We may, but have no obligation to, remove Content and Accounts containing
-  Content that we determine in our sole discretion are unlawful, offensive,
-  threatening, libelous, defamatory, pornographic, obscene or otherwise
-  objectionable or violates any party's intellectual property or these Terms of
-  Service.
-- Verbal, physical, written or other abuse (including threats of abuse or
-  retribution) of any Shorebird customer, employee, member, or officer will result
-  in immediate account termination.
-- You understand that the technical processing and transmission of the Service,
-  including your Content, may be transferred unencrypted and involve (a)
-  transmissions over various networks; and (b) changes to conform and adapt to
-  technical requirements of connecting networks or devices.
-- You must not upload, post, host, or transmit unsolicited email, SMSs, or
-  "spam" messages.
-- You must not transmit any worms or viruses or any code of a destructive
-  nature.
-- If your bandwidth usage significantly exceeds the average bandwidth usage (as
-  determined solely by Shorebird) of other Shorebird customers, we reserve the
-  right to immediately disable your account or throttle your file hosting until
-  you can reduce your bandwidth consumption.
-- Shorebird does not warrant that (i) the service will meet your specific
-  requirements, (ii) the service will be uninterrupted, timely, secure, or
-  error-free, (iii) the results that may be obtained from the use of the service
-  will be accurate or reliable, (iv) the quality of any products, services,
-  information, or other material purchased or obtained by you through the service
-  will meet your expectations, and (v) any errors in the Service will be
-  corrected.
-- You expressly understand and agree that Shorebird shall not be liable for any
-  direct, indirect, incidental, special, consequential or exemplary damages,
-  including but not limited to, damages for loss of profits, goodwill, use, data
-  or other intangible losses (even if Shorebird has been advised of the
-  possibility of such damages), resulting from: (i) the use or the inability to
-  use the service; (ii) the cost of procurement of substitute goods and services
-  resulting from any goods, data, information or services purchased or obtained or
-  messages received or transactions entered into through or from the service;
-  (iii) unauthorized access to or alteration of your transmissions or data; (iv)
-  statements or conduct of any third-party on the service; (v) or any other matter
-  relating to the service.
-- The failure of Shorebird to exercise or enforce any right or provision of the
-  Terms of Service shall not constitute a waiver of such right or provision. The
-  Terms of Service constitutes the entire agreement between you and Shorebird and
-  govern your use of the Service, superseding any prior agreements between you and
-  Shorebird (including, but not limited to, any prior versions of the Terms of
-  Service). You agree that these Terms of
-- Service and Your use of the Service are governed under California law.
+THE SERVICES ARE PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS. USE OF THE
+SERVICES ARE AT YOUR OWN RISK. THE SERVICES ARE PROVIDED WITHOUT WARRANTIES OF
+ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NON-INFRINGEMENT. WITHOUT LIMITING THE FOREGOING, SHOREBIRD, ITS AFFILIATES, AND
+ITS LICENSORS DO NOT WARRANT THAT THE SERVICES ARE ACCURATE, RELIABLE OR
+CORRECT; THAT THE SERVICES WILL MEET YOUR REQUIREMENTS; THAT THE SERVICES WILL
+BE AVAILABLE AT ANY PARTICULAR TIME OR LOCATION, UNINTERRUPTED OR SECURE; THAT
+ANY DEFECTS OR ERRORS WILL BE CORRECTED; OR THAT THE SERVICES ARE FREE OF
+VIRUSES OR OTHER HARMFUL COMPONENTS.
+
+## L. Limitation of Liability.
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL SHOREBIRD,
+ITS AFFILIATES, OFFICERS, DIRECTORS, EMPLOYEES, AGENTS, OR ITS LICENSORS BE
+LIABLE FOR ANY INDIRECT, PUNITIVE, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR
+EXEMPLARY DAMAGES, INCLUDING WITHOUT LIMITATION DAMAGES FOR LOSS OF PROFITS,
+GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES, THAT RESULT FROM THE USE OF, OR
+INABILITY TO USE, THE SERVICES. SHOREBIRD’S MAXIMUM AGGREGATE LIABILITY ARISING
+OUT OF OR RELATING TO THIS AGREEMENT, REGARDLESS OF THE THEORY OF LIABILITY,
+WILL BE LIMITED TO THE TOTAL FEES PAID BY YOU TO SHOREBIRD HEREUNDER FOR THE
+TWELVE-MONTH PERIOD IMMEDIATELY PRECEDING THE DATE THE CAUSE OF ACTION AROSE, IF
+ANY. THE EXISTENCE OF MORE THAN ONE CLAIM SHALL NOT EXPAND SUCH LIMIT.
+
+THIS LIMITATION OF LIABILITY SECTION APPLIES WHETHER THE ALLEGED LIABILITY IS
+BASED ON CONTRACT, TORT, NEGLIGENCE, STRICT LIABILITY, OR ANY OTHER BASIS, EVEN
+IF SHOREBIRD HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THE FOREGOING
+LIMITATION OF LIABILITY SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW IN
+THE APPLICABLE JURISDICTION.
+
+## M. General Conditions.
+
+- You acknowledge and agree that the Services may be subject to export controls
+  and regulations imposed by the United States government or other relevant
+  authorities ("Export Laws"). You agree to comply fully with all applicable
+  Export Laws, including but not limited to the Export Administration
+  Regulations (EAR) administered by the U.S. Department of Commerce and the
+  International Traffic in Arms Regulations (ITAR) administered by the U.S.
+  Department of State. You agree not to divert, export, re-export, or transfer
+  any product, technology, or technical data received from Shorebird to any
+  end-user, entity, or destination that is prohibited or restricted by
+  applicable Export Laws.
+- Entire Agreement. This Agreement, together with any other legal notices and
+  agreements published by Shorebird via the Services, shall constitute the
+  entire agreement between you and Shorebird concerning the Services.
+- No Waiver. Shorebird’s failure to assert any right or provision under this
+  Agreement shall not constitute a waiver of such right or provision, and no
+  waiver of any term of this Agreement shall be deemed a further or continuing
+  waiver of such term or any other term.
+- Headings. The section titles in this Agreement are for convenience only and
+  have no legal or contractual effect.
+- Severability. If any provision of this Agreement is unlawful, void or
+  unenforceable by a court of competent jurisdiction, that provision is deemed
+  severable from this Agreement and does not affect the validity and
+  enforceability of any remaining provisions.
+- Governing Law. You agree that the Agreement and Your use of the Services are
+  governed under California law.
 
 Questions about the Terms of Service should be sent to contact@shorebird.dev

--- a/src/pages/terms/index.md
+++ b/src/pages/terms/index.md
@@ -2,12 +2,12 @@
 layout: ../../layouts/MarkdownLayout.astro
 title: Terms of Use
 description: Shorebird Terms of Use
-last_updated: 02-29-2024
+last_updated: 03-04-2024
 ---
 
 # Terms of Service
 
-Last updated and Effective as of February 29, 2024.
+Last updated and Effective as of March 4th, 2024.
 
 THESE TERMS OF SERVICE (“TERMS OF SERVICE” OR “AGREEMENT”) GOVERN YOUR USE OF
 THE SHOREBIRD.DEV WEBSITE AND/OR ANY OF THE SERVICES OFFERED BY CODE TOWN, INC.


### PR DESCRIPTION
This replaces our previous 2023 TOS for all customers.

Our 2023 TOS were written by me (a non-lawyer), cribbed from what
expo.dev was using for their Terms at the time.  This set is
written by an actual lawyer, with the goals of:
1. Be as much like every other Saas.
2. Make it easy for companies to adopt Shorebird.

Terms are currently scheduled to go into affect on Feb 24, 2024
for new customers, and March 24, 2024 for existing customers.
All customers will be required to make an affirmative accept
before those dates to continue using the services.

<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
