### PR TITLE
enhancement(build): Replacing npm install with npm ci as it quicker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY ./package.json ./
 COPY ./package-lock.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 


### PR DESCRIPTION
## Status
**READY**

## Description

npm ci (also known as clean-install) is most suited for building docker images for deployments and release, as it only install the packages and dependent packages from package-lock.json, where npm install fetches dependencies and dependent packages during that time from package.json and generates new package-lock.json and could update packages which introduce new unexpected behaviors. See more here [`npm ci`](https://docs.npmjs.com/cli/v9/commands/npm-ci)

#### What does it do for shorebird build
It reduces significantly the installation time during building docker
`npm install` took `139s`  where
`npm ci` took `129s`
we got `10s` :)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
