### PR TITLE
Add 'Can shorebird see my code' to FAQ

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -25,6 +25,11 @@ const faqs = [
       'Yes! Shorebird has been used in production by thousands of apps since early 2023.',
   },
   {
+    question: 'Can Shorebird see my code?',
+    answer:
+      'No. Shorebird does not store any of your source code on our servers. The patches we store are binary diffs of your compiled code, which are not human-readable.',
+  },
+  {
     question: 'Are there any limitations or known issues?',
     answer:
       'We keep a list of known issues at [https://docs.shorebird.dev/status](https://docs.shorebird.dev/status).',


### PR DESCRIPTION
We've received a number of questions from (potential) users re: the level of access we have to their code and what we store. This adds an FAQ entry to address that.