### PR TITLE
chore: small updates to pricing page

### DIFF
--- a/src/components/PricingDetails.tsx
+++ b/src/components/PricingDetails.tsx
@@ -101,6 +101,7 @@ const features: Feature[] = [
     teams: 'Admin, Developer, Billing, View-Only',
     custom: 'Custom',
   },
+  { title: 'Invoice Billing', custom: '✓' },
   { title: 'Annual Billing', teams: '✓', custom: '✓' },
   // { title: 'White-Label Support', teams: '✓', enterprise: '✓' },
   { title: 'SAML', custom: 'Custom' },
@@ -126,7 +127,7 @@ export const PricingDetails = () => {
       name: 'Custom',
       price: 'Custom',
       description: 'For large apps with custom needs.',
-      cta: { link: config.contactSales, title: 'Schedule a Call' },
+      cta: { link: config.contactSales, title: 'Talk to Sales' },
     },
   ];
 

--- a/src/components/PricingOverview.tsx
+++ b/src/components/PricingOverview.tsx
@@ -65,9 +65,9 @@ function PricesNote() {
 
 function FreePlan() {
   const features: Feature[] = [
-    { title: 'Unlimited apps' },
-    { title: '1 developer' },
     { title: '5K patch installs/month' },
+    { title: '1 developer' },
+    { title: 'Unlimited apps' },
     { title: 'Community support' },
   ];
   return (
@@ -111,8 +111,8 @@ function ProPlan() {
       title: '50K patch installs/month',
       caption: 'then $1 per 2,500 patch installs.',
     },
-    { title: 'Unlimited apps' },
     { title: 'Unlimited developers' },
+    { title: 'Unlimited apps' },
     { title: 'Community support' },
   ];
   return (
@@ -153,9 +153,9 @@ function ProPlan() {
 
 function EnterprisePlan() {
   const features: Feature[] = [
-    { title: 'Unlimited apps' },
+    { title: 'Volume discounts' },
     { title: 'Unlimited developers' },
-    { title: 'High volume discounts' },
+    { title: 'Unlimited apps' },
     { title: 'Private Support' },
   ];
   return (
@@ -171,7 +171,7 @@ function EnterprisePlan() {
             </div>
           </div>
           <p className="mb-4 mt-4 text-left leading-loose text-gray-500">
-            For very large apps.
+            For large apps with custom needs.
           </p>
           <ul className="mb-2 text-white 2xl:mb-6">
             {features.map((feature, index) => (

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ export const config = {
   githubUrl: 'https://github.com/shorebirdtech/shorebird',
   twitterUrl: 'https://twitter.com/shorebirddev',
   consoleUrl: 'https://console.shorebird.dev',
-  contactSales: 'https://calendly.com/eseidel/shorebird-demo',
+  contactSales: 'https://calendly.com/eseidel/shorebird-sales',
   contactEmail: 'contact@shorebird.dev',
   navLinks: [
     { label: 'Products', href: '/#products-code-push', ariaLabel: 'Products' },


### PR DESCRIPTION
Use a new (30m) URL for sales calls and make it clear its speaking to sales more generally rather than implying a demo.