### PR TITLE
feat: Use /contact for our contact page

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -95,7 +95,7 @@ export const Footer = () => {
                   <li className="mb-4">
                     <a
                       className="text-gray-400 hover:text-gray-300"
-                      href={`mailto:${config.contactEmail}`}
+                      href="/contact"
                       aria-label="contact us"
                     >
                       Contact Us

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -6,17 +6,26 @@ description: Contact Shorebird
 
 # Contact
 
-## Support
+## 🛟 Support
 
-Shorebird [Discord](https://discord.gg/shorebird) is the fastest way to get
-support.
+Filing an issue on [GitHub](https://github.com/shorebirdtech/shorebird/issues/new/choose) is the most direct to record the necessary information for us to help.
 
-Paying Shorebird customers are eligible for private support via a private
-Discord channel. Ask any Shorebird team member for access.
+[Discord](https://discord.gg/shorebird) reaches our team via live chat.
 
-You can also [email us](mailto:contact@shorebird.dev), but we're slower to
-respond there.
+Paying Shorebird customers can access private support channels
+on Discord by messaging a Shorebird team member.
 
-## Sales
+You're also welcome to [email us](mailto:contact@shorebird.dev).
 
-[Email](mailto:contact@shorebird.dev) is the best way to reach our sales team.
+## 🏷️ Sales
+
+[Email](contact@shorebird.dev) our sales team or [schedule a call](https://calendly.com/eseidel/shorebird-sales).
+
+## 🐌 Mail
+
+Shorebird is globally remote, we have no physical office.  Contracts or physical mail should use:
+
+```
+2261 Market Street #5112
+San Francisco, CA 94114-1612
+```

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -23,7 +23,7 @@ You're also welcome to [email us](mailto:contact@shorebird.dev).
 
 ## 🐌 Mail
 
-Shorebird is globally remote, we have no physical office.  Contracts or physical mail should use:
+Shorebird is globally remote, we have no physical office. Contracts or physical mail should use:
 
 ```
 2261 Market Street #5112


### PR DESCRIPTION
The page existed, we just weren't using it.

This came up because a contract needed our physical address and I realized it wasn't on our site.