### PR TITLE
feat: add more og tags to our blogs

### DIFF
--- a/src/components/Author.astro
+++ b/src/components/Author.astro
@@ -9,26 +9,30 @@ interface Author {
   title: string;
   avatar: ImageMetadata;
   github: string;
+  twitter?: string;
 }
 
-const authors: Record<string, Author> = {
+export const authors: Record<string, Author> = {
   shorebirdtech: {
     name: 'Shorebird',
     title: 'The Shorebird Team',
     avatar: shorebirdHeadshot,
     github: 'shorebirdtech',
+    twitter: '@shorebirddev',
   },
   eseidel: {
     name: 'Eric Seidel',
     title: 'Founder & CEO',
     avatar: ericHeadshot,
     github: 'eseidel',
+    twitter: '@_eseidel',
   },
   felangel: {
     name: 'Felix Angelov',
     title: 'Founding Engineer',
     avatar: felixHeadshot,
     github: 'felangel',
+    twitter: '@felangelov',
   },
   bryanoltman: {
     name: 'Bryan Oltman',
@@ -40,6 +44,7 @@ const authors: Record<string, Author> = {
 
 const { handle } = Astro.props;
 const author = authors[handle];
+
 ---
 
 <div class="flex items-center">

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -6,7 +6,7 @@ import '@fontsource/inter/700.css';
 import '@fontsource/inter/800.css';
 import '@fontsource/inter/900.css';
 import { config } from '~/config';
-import Author from '~/components/Author.astro';
+import  Author, { authors } from '~/components/Author.astro';
 import FormattedDate from '~/components/FormattedDate.astro';
 import { Navbar } from '~/components/Navbar';
 import { Footer } from '~/components/Footer';
@@ -33,6 +33,13 @@ const { title, description, author, date, cover, coverAlt } = Astro.props;
     <meta name="twitter:image" content={cover ? cover : '/open-graph.png'} />
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site)} />
+    <meta property="og:type" content="article" />
+    <meta property="article:published_time" content={date} />
+    <meta property="article:author" content={author} />
+    <meta property="article:section" content="Technology" />
+    <meta name="twitter:site" content="@shorebirddev" />
+    {authors[author].twitter && <meta name="twitter:creator" content={authors[author].twitter} />}
+    <!--  Could add tags here if we add them to the blog props -->
     <script
       defer
       data-domain="shorebird.dev"


### PR DESCRIPTION
This includes the twitter tags:
https://developer.x.com/en/docs/x-for-websites/cards/guides/getting-started
And the "article" type tags:
https://ogp.me/#type_article