### PR TITLE
feat: add vanity url for newsletter signup

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
+import config from './src/config';
 
 // https://astro.build/config
 export default defineConfig({
@@ -18,5 +19,6 @@ export default defineConfig({
     '/faq': 'https://docs.shorebird.dev/faq',
     '/security': 'https://handbook.shorebird.dev/security',
     '/workshops': 'https://calendly.com/felix-shorebird/shorebird-workshop',
+    '/newsletter-signup': config.newsletterSubscriptionUrl,
   },
 });


### PR DESCRIPTION
## Status

**READY**

## Description

Adding in a vanity URL for sending people to the newsletter signup form. Allows us to post a Shorebird URL for that flow instead of a weird MailChimp one.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
