### PR TITLE
fix: removing broken images from visible story

### DIFF
--- a/src/content/success-stories/visible.md
+++ b/src/content/success-stories/visible.md
@@ -33,11 +33,6 @@ Beyond new features, quick bug fixes were equally important—especially in a he
 >
 > - Dominik Roszkowski, Lead Engineer at Visible
 
-<p align="center">
-  <img alt="Light" src="/src/assets/success-stories/visible-screenshot.png" align="left" style="max-width: 50%;max-height:100%;padding-right:10px;">
-  <img alt="Dark" src="/src/assets/success-stories/visible-screenshot-2.png" align="right" style="max-width: 50%;max-height:100%;padding-left:10px;">
-</p>
-
 **The Solution: Seamless Over-the-Air Updates with Shorebird**
 
 Visible integrated Shorebird into their CI pipeline to streamline their releases. With Shorebird, the team can push updates—both features and fixes—directly to users, bypassing the delays of traditional app store deployments.


### PR DESCRIPTION
## Status

**READY**

## Description

Pulling the app images out of the Visible success story as they were broken. Need to do more work to get them rendered correctly.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
