### PR TITLE
chore: add consistent prettier rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -7,7 +7,8 @@ labels: chore
 
 **Description**
 
-Clearly describe what change is needed and why. If this changes code then please use another issue type.
+Clearly describe what change is needed and why. If this changes code then please
+use another issue type.
 
 **Requirements**
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,6 +1,7 @@
 ---
 name: Documentation
-about: Improve the documentation so all collaborators have a common understanding
+about:
+  Improve the documentation so all collaborators have a common understanding
 title: 'docs: '
 labels: documentation
 ---

--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -7,7 +7,8 @@ labels: performance
 
 **Description**
 
-Clearly describe what code needs to be changed and what the performance impact is going to be. Bonus point's if you can tie this directly to user experience.
+Clearly describe what code needs to be changed and what the performance impact
+is going to be. Bonus point's if you can tie this directly to user experience.
 
 **Requirements**
 

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -7,7 +7,8 @@ labels: refactor
 
 **Description**
 
-Clearly describe what needs to be refactored and why. Please provide links to related issues (bugs or upcoming features) in order to help prioritize.
+Clearly describe what needs to be refactored and why. Please provide links to
+related issues (bugs or upcoming features) in order to help prioritize.
 
 **Requirements**
 

--- a/.github/ISSUE_TEMPLATE/style.md
+++ b/.github/ISSUE_TEMPLATE/style.md
@@ -1,6 +1,8 @@
 ---
 name: Style Changes
-about: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+about:
+  Changes that do not affect the meaning of the code (white-space, formatting,
+  missing semi-colons, etc)
 title: 'style: '
 labels: style
 ---

--- a/.github/ISSUE_TEMPLATE/test.md
+++ b/.github/ISSUE_TEMPLATE/test.md
@@ -7,7 +7,8 @@ labels: test
 
 **Description**
 
-List out the tests that need to be added or changed. Please also include any information as to why this was not covered in the past.
+List out the tests that need to be added or changed. Please also include any
+information as to why this was not covered in the past.
 
 **Requirements**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,8 @@
 
 - [ ] ✨ New feature (non-breaking change which adds functionality)
 - [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] ❌ Breaking change (fix or feature that would cause existing functionality
+      to change)
 - [ ] 🧹 Code refactor
 - [ ] ✅ Build configuration change
 - [ ] 📝 Documentation

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "plugins": ["prettier-plugin-tailwindcss"],
-  "singleQuote": true
+  "singleQuote": true,
+  "printWidth": 80,
+  "proseWrap": "always"
 }

--- a/src/content/blog/1.0.md
+++ b/src/content/blog/1.0.md
@@ -1,20 +1,24 @@
 ---
 title: Shorebird 1.0
 author: shorebirdtech
-description: Announcing Shorebird Code Push 1.0 including stable support for iOS and how to get started.
+description:
+  Announcing Shorebird Code Push 1.0 including stable support for iOS and how to
+  get started.
 date: 2024-04-08
 cover: '1.0-cover.png'
 slug: '1.0'
 ---
 
-We’re excited to announce Shorebird Code Push 1.0, including stable support for iOS!
+We’re excited to announce Shorebird Code Push 1.0, including stable support for
+iOS!
 
 ## 🐦 What is Shorebird?
 
 Shorebird allows you to update your Flutter apps instantly over the air,
-deploying fixes directly to end users' devices. Shorebird can be [integrated into
-your app](https://docs.shorebird.dev) in under 5 minutes and requires no code changes. With Shorebird, you
-can update any Dart code in your app instantly.
+deploying fixes directly to end users' devices. Shorebird can be
+[integrated into your app](https://docs.shorebird.dev) in under 5 minutes and
+requires no code changes. With Shorebird, you can update any Dart code in your
+app instantly.
 
 Shorebird is built to comply with
 [Apple](https://docs.shorebird.dev/faq#does-shorebird-comply-with-app-store-guidelines)
@@ -27,11 +31,12 @@ grows.
 
 ## 🚀 Get Started
 
-Get started now with our [Quick Start
-Guide](https://docs.shorebird.dev/guides/code_push_quickstart)!
+Get started now with our
+[Quick Start Guide](https://docs.shorebird.dev/guides/code_push_quickstart)!
 
 iOS stable requires the latest version of Shorebird CLI (1.0.0) and the latest
-stable version of Flutter (3.19.5). Known issues are tracked on our [status page](https://docs.shorebird.dev/status).
+stable version of Flutter (3.19.5). Known issues are tracked on our
+[status page](https://docs.shorebird.dev/status).
 
 Code is available on [GitHub](https://github.com/shorebirdtech/shorebird).
 

--- a/src/content/blog/brand-refresh.md
+++ b/src/content/blog/brand-refresh.md
@@ -13,7 +13,8 @@ much-needed brand refresh!
 
 ### Redesigned Website
 
-We're super excited to announce the next iteration of [shorebird.dev](https://shorebird.dev) 🥳
+We're super excited to announce the next iteration of
+[shorebird.dev](https://shorebird.dev) 🥳
 
 ![New Site Design](../../assets/blog/brand-refresh/new-site-design.png)
 
@@ -27,10 +28,11 @@ non-technical folks.
 We also took this as an opportunity to refresh our logo. Our goal was to polish
 and simplify where possible while still maintaining the cute, playful sandpiper.
 
-_Fun Fact: Did you know the name Shorebird is the name of the street on which Flutter was created?_
+_Fun Fact: Did you know the name Shorebird is the name of the street on which
+Flutter was created?_
 
-![Refreshed Logo](../../assets/blog/brand-refresh/refreshed-logo.png)
-_Old Logo (left), Refreshed Logo (right)_
+![Refreshed Logo](../../assets/blog/brand-refresh/refreshed-logo.png) _Old Logo
+(left), Refreshed Logo (right)_
 
 We also revisited and adjusted our core brand assets including our typography,
 color palette, and more.

--- a/src/content/blog/buy-dont-build.md
+++ b/src/content/blog/buy-dont-build.md
@@ -1,7 +1,9 @@
 ---
 title: The Smarter Way to Ship Flutter Updates
 author: tomarra
-description: Learning from enterprise players that custom code deployment systems are valuable but a lot to maintain.
+description:
+  Learning from enterprise players that custom code deployment systems are
+  valuable but a lot to maintain.
 date: 2025-02-24
 cover: buy-dont-build-cover.png
 ---
@@ -10,22 +12,58 @@ cover: buy-dont-build-cover.png
 
 Sometimes, the best engineering solution isn’t to build—it’s to buy.
 
-That’s a lesson many companies learn the hard way when tackling the problem of mobile app updates. For companies that rely on fast iteration cycles, the limitations of the App Store and Google Play’s release process can be a major bottleneck. Engineering teams often invest months—or even years—developing internal solutions to push updates dynamically, only to find that maintaining these systems is just as challenging as building them. But what if you didn’t have to build your own solution? What if you could buy it?
+That’s a lesson many companies learn the hard way when tackling the problem of
+mobile app updates. For companies that rely on fast iteration cycles, the
+limitations of the App Store and Google Play’s release process can be a major
+bottleneck. Engineering teams often invest months—or even years—developing
+internal solutions to push updates dynamically, only to find that maintaining
+these systems is just as challenging as building them. But what if you didn’t
+have to build your own solution? What if you could buy it?
 
 ## Learning from Nubank: A Case for Dynamic Updates
 
-This idea crystallized for me while listening to [Build to Succeed](https://verygood.ventures/podcasts), a podcast episode featuring [Thiago Ghisi from Nubank](https://www.linkedin.com/in/thiagoghisi/). [Nubank](https://nubank.com.br/en/), one of the largest fintech companies in the world, serves over 100 million customers with its mobile-first platform and [has been using Flutter](https://building.nubank.com.br/scaling-with-flutter/) for a number of years. Given the scale and pace at which Nubank operates, they needed a way to bypass the friction of app store release cycles. Their solution? A sophisticated server-driven UI framework that allowed them to push UI updates without requiring users to download a new version of the app.
+This idea crystallized for me while listening to
+[Build to Succeed](https://verygood.ventures/podcasts), a podcast episode
+featuring [Thiago Ghisi from Nubank](https://www.linkedin.com/in/thiagoghisi/).
+[Nubank](https://nubank.com.br/en/), one of the largest fintech companies in the
+world, serves over 100 million customers with its mobile-first platform and
+[has been using Flutter](https://building.nubank.com.br/scaling-with-flutter/)
+for a number of years. Given the scale and pace at which Nubank operates, they
+needed a way to bypass the friction of app store release cycles. Their solution?
+A sophisticated server-driven UI framework that allowed them to push UI updates
+without requiring users to download a new version of the app.
 
-During this episode Thiago described how this approach emerged as a necessity rather than a luxury. With hundreds of screens and a mobile engineering team struggling to keep up with demand, they needed a scalable way to ship updates multiple times a day. By moving logic to the backend, Nubank could iterate faster, conduct A/B tests more effectively, and reduce dependency on mobile engineers for UI changes.
+During this episode Thiago described how this approach emerged as a necessity
+rather than a luxury. With hundreds of screens and a mobile engineering team
+struggling to keep up with demand, they needed a scalable way to ship updates
+multiple times a day. By moving logic to the backend, Nubank could iterate
+faster, conduct A/B tests more effectively, and reduce dependency on mobile
+engineers for UI changes.
 
-But this approach wasn’t built overnight. It took years of iteration, countless challenges, and a significant engineering investment to get right. And it’s a lesson for other companies—one that Shorebird is helping other businesses avoid.
+But this approach wasn’t built overnight. It took years of iteration, countless
+challenges, and a significant engineering investment to get right. And it’s a
+lesson for other companies—one that Shorebird is helping other businesses avoid.
 
 ## Shorebird: App Updates Without the Pain
 
-Shorebird provides a ready-made solution for companies looking to achieve what Nubank did – over the air updates – without the time, effort, and cost of building it from scratch. Our instant update technology allows mobile teams to update their apps instantly, without waiting for app store approvals or worrying about fragmented user adoption.
+Shorebird provides a ready-made solution for companies looking to achieve what
+Nubank did – over the air updates – without the time, effort, and cost of
+building it from scratch. Our instant update technology allows mobile teams to
+update their apps instantly, without waiting for app store approvals or worrying
+about fragmented user adoption.
 
-At Shorebird, we believe in empowering businesses to be successful with Flutter. Our mission is to make multi-platform development the default way all developers build software. We understand that in today’s fast-paced world, companies need the ability to iterate quickly and deploy changes seamlessly. That’s why we’ve built Shorebird—to remove the barriers of app store releases and allow businesses to focus on what matters most: delivering exceptional user experiences.
+At Shorebird, we believe in empowering businesses to be successful with Flutter.
+Our mission is to make multi-platform development the default way all developers
+build software. We understand that in today’s fast-paced world, companies need
+the ability to iterate quickly and deploy changes seamlessly. That’s why we’ve
+built Shorebird—to remove the barriers of app store releases and allow
+businesses to focus on what matters most: delivering exceptional user
+experiences.
 
-If your engineering team is considering building an internal code push system, ask yourself: is this really the best use of your resources? Nubank’s story shows that while the benefits of dynamic updates are clear, the road to building them yourself is long and complex.
+If your engineering team is considering building an internal code push system,
+ask yourself: is this really the best use of your resources? Nubank’s story
+shows that while the benefits of dynamic updates are clear, the road to building
+them yourself is long and complex.
 
-With Shorebird, you can skip the years of development and get straight to the benefits. Why build when you can buy?
+With Shorebird, you can skip the years of development and get straight to the
+benefits. Why build when you can buy?

--- a/src/content/blog/cloud-infra-improvements.md
+++ b/src/content/blog/cloud-infra-improvements.md
@@ -1,7 +1,9 @@
 ---
 title: Improved Cloud Infrastructure
 author: felangel
-description: A deep dive into some of the recent backend infrastructure improvements we've made.
+description:
+  A deep dive into some of the recent backend infrastructure improvements we've
+  made.
 date: 2025-04-17
 cover: improved-cloud-infra-cover.png
 ---
@@ -76,9 +78,9 @@ topic, and various subscribers performing the expensive computations
 asynchronously and caching the results for the patch check service to consume
 directly.
 
-This dramatically reduced the latency and overall compute needed per update check
-request. We went from requests occasionally taking >1s during sudden spikes in
-request volume to 99% of our request completing in <300ms.
+This dramatically reduced the latency and overall compute needed per update
+check request. We went from requests occasionally taking >1s during sudden
+spikes in request volume to 99% of our request completing in <300ms.
 
 ![patch check latency improvements](../../assets/blog/improved-cloud-infra/patch-check-latency-improvements.png)
 
@@ -108,8 +110,8 @@ reduced pageload time by up to 10x.
 ![insights page loads](../../assets/blog/improved-cloud-infra/insights-page-loads.png)
 
 We also adjusted all other jobs which previously read directly from BigQuery to
-instead query the time series database and observed significant improvements
-in the time to complete each job.
+instead query the time series database and observed significant improvements in
+the time to complete each job.
 
 | Job             |   Before   |   After   |
 | --------------- | :--------: | :-------: |
@@ -123,5 +125,5 @@ That's all for now!
 These infrastructure improvements are already rolled out to all Shorebird
 customers around the world. 🥳
 
-If you're new to Shorebird and want to get started, head over to the [Shorebird
-Console](https://console.shorebird.dev).
+If you're new to Shorebird and want to get started, head over to the
+[Shorebird Console](https://console.shorebird.dev).

--- a/src/content/blog/dart-3.5.0.md
+++ b/src/content/blog/dart-3.5.0.md
@@ -7,11 +7,11 @@ cover: dart-3.5-cover.png
 slug: 'dart-3.5.0'
 ---
 
-One of the big features of [Flutter
-3.24.0](https://medium.com/flutter/whats-new-in-flutter-3-24-6c040f87d1e4) is an
-upgrade to Dart 3.5.0, which comes with a whole bunch of [nice
-changes](https://medium.com/dartlang/dart-3-5-6ca36259fa2f). Unfortunately, like
-all software releases, it also came with some bugs.
+One of the big features of
+[Flutter 3.24.0](https://medium.com/flutter/whats-new-in-flutter-3-24-6c040f87d1e4)
+is an upgrade to Dart 3.5.0, which comes with a whole bunch of
+[nice changes](https://medium.com/dartlang/dart-3-5-6ca36259fa2f).
+Unfortunately, like all software releases, it also came with some bugs.
 
 We encountered some bugs when upgrading our projects at Shorebird and have
 listed the problems and workarounds we found here:

--- a/src/content/blog/dart-macros.md
+++ b/src/content/blog/dart-macros.md
@@ -14,13 +14,12 @@ at Google in 2014 and led the Flutter (and later Dart) teams at Google until
 2022 when I left to found this company, Shorebird. Shorebird sells products to
 teams using Flutter and I remain deeply involved and invested in Flutter and
 Dart's success. Flutter has been “dying” or “about to be canceled by Google”
-since we started the project 10 years ago. So I guess if "accounting for [1/3rd
-of app submissions to
-AppStore](https://medium.com/flutter/flutter-in-production-f9418261d8e1) or
-Play” is what "dying" looks like, I’m here for it. 🙂
+since we started the project 10 years ago. So I guess if "accounting for
+[1/3rd of app submissions to AppStore](https://medium.com/flutter/flutter-in-production-f9418261d8e1)
+or Play” is what "dying" looks like, I’m here for it. 🙂
 
-Today, Google's Dart team announced they are [stopping their work on "macros"
-](https://medium.com/dartlang/an-update-on-dart-macros-data-serialization-06d3037d4f12).
+Today, Google's Dart team announced they are
+[stopping their work on "macros" ](https://medium.com/dartlang/an-update-on-dart-macros-data-serialization-06d3037d4f12).
 Macros was planned as a new language feature to make it easier for Flutter and
 Dart developers to express ideas requiring repetitive code (for example data
 serialization) from simple syntax. C++, Rust, etc. all have variants of a
@@ -32,8 +31,8 @@ Two reasons Google took this step:
 
 1. They’ve realized they can’t make macros pass their performance goals (without
    other even larger changes to the ecosystem or language).
-2. The years of prototyping macros (with its ambitious scope), hasn’t been
-   worth the effort/reward tradeoff.
+2. The years of prototyping macros (with its ambitious scope), hasn’t been worth
+   the effort/reward tradeoff.
 
 Google is now breaking macros into smaller features and shipping those, and then
 throwing out the parts of macros that they couldn’t make perform well enough to
@@ -55,12 +54,12 @@ build many more things, but we’re choosing to focus on instant updates for now
 
 The macros work started while I still led the Dart team over 2 years ago. This
 long development cycle (and public discussion thereof) has allowed macros grow
-in the public consciousness to be seen as Dart’s coming magic bullet, here
-to solve all our problems at once. It never was, and never could be.
+in the public consciousness to be seen as Dart’s coming magic bullet, here to
+solve all our problems at once. It never was, and never could be.
 
-Obviously, I wish the team had reached a go/no-go earlier, but
-I’m glad they have now. Hopefully now we get a bunch of interesting smaller
-things this year as a result. We’ll see.
+Obviously, I wish the team had reached a go/no-go earlier, but I’m glad they
+have now. Hopefully now we get a bunch of interesting smaller things this year
+as a result. We’ll see.
 
 The Google Dart team and wider community are full of passionate and talented
 people. I’m looking forward to see what amazing things we do next.

--- a/src/content/blog/desktop-in-production.md
+++ b/src/content/blog/desktop-in-production.md
@@ -29,6 +29,6 @@ The patching mechanism for each of these platforms does not use a simulator, so
 there is no performance penalty when running patched code.
 
 If you’re using Flutter on desktop, we’d love to hear from you! Let us know if
-you run into any issues or have ideas for new features by creating a [new GitHub
-issue](https://github.com/shorebirdtech/shorebird/issues/new?template=Blank+issue).
+you run into any issues or have ideas for new features by creating a
+[new GitHub issue](https://github.com/shorebirdtech/shorebird/issues/new?template=Blank+issue).
 You can also reach us on [Discord](https://discord.gg/shorebird).

--- a/src/content/blog/development-workflow.md
+++ b/src/content/blog/development-workflow.md
@@ -6,13 +6,13 @@ date: 2024-09-25
 cover: development-workflow-cover.png
 ---
 
-Our customers have been asking for an opinionated development workflow
-which integrates Shorebird so that they can spend more time shipping and less
-time defining and building a release/patch pipeline that integrates Shorebird.
+Our customers have been asking for an opinionated development workflow which
+integrates Shorebird so that they can spend more time shipping and less time
+defining and building a release/patch pipeline that integrates Shorebird.
 
-We're excited to announce that we've put together a [development
-workflow guide](https://docs.shorebird.dev/guides/development-workflow) which
-includes:
+We're excited to announce that we've put together a
+[development workflow guide](https://docs.shorebird.dev/guides/development-workflow)
+which includes:
 
 - 🪵 Branching and tagging strategy
 - ✅ Automated continuous integration checks

--- a/src/content/blog/flutter-jobs.md
+++ b/src/content/blog/flutter-jobs.md
@@ -10,9 +10,9 @@ I founded the Flutter project 10 years ago, and led the Flutter team at Google
 for 8 years. I'm reasonably well known in the Flutter community and receive a
 lot of email from both job-seekers and job-posters regarding Flutter.
 
-I've also been a manager for a decade and can tell you, hiring is hard—from
-both sides. It's hard for companies to find candidates, and it's hard for
-candidates to find companies.
+I've also been a manager for a decade and can tell you, hiring is hard—from both
+sides. It's hard for companies to find candidates, and it's hard for candidates
+to find companies.
 
 This can be made extra-hard when trying to search for a subset of jobs which
 include a specific technology choice, like Flutter.
@@ -21,17 +21,17 @@ I generally try to dissuade both job-seekers and job-posters to search
 specifically for Flutter, under the belief that Flutter is a tool -- a means to
 an end -- and like other tools will come and go in popularity over time and what
 we all (ideally) focus on in our jobs is solving customer problems. As
-technologists, we learn whatever tools we need to do accomplish that
-goal including Flutter.
+technologists, we learn whatever tools we need to do accomplish that goal
+including Flutter.
 
 The difference is subtle, but I believe important. Most places that should be
 using Flutter may not know they should be using Flutter (because they haven't
-hired the person to make that choice yet). Similarly, many developers who will be
-successful with Flutter may not be using it yet, because they're using whatever
-technology is required by their current role to solve current problems.
+hired the person to make that choice yet). Similarly, many developers who will
+be successful with Flutter may not be using it yet, because they're using
+whatever technology is required by their current role to solve current problems.
 
-That said, people understandably search for and advertise for "flutter jobs"
-and so here are some tips I give to be successful with such.
+That said, people understandably search for and advertise for "flutter jobs" and
+so here are some tips I give to be successful with such.
 
 ### A as a Job Seeker
 
@@ -78,8 +78,8 @@ I've personally worked with, and can attest to being excellent:
 
 - https://hnhiring.com/ -- A site which aggregates "Who's hiring" posts from
   Hacker News.
-- https://job.zip/jobs/flutter -- Some job-aggregation startup, but
-  also the best technology-based jobs aggregator I've found.
+- https://job.zip/jobs/flutter -- Some job-aggregation startup, but also the
+  best technology-based jobs aggregator I've found.
 - LinkedIn. I've not found a lot of success personally on LinkedIn, but there is
   a lot of volume there.
 - Twitter. I (https://x.com/@_eseidel) post about jobs involving Flutter when
@@ -147,18 +147,18 @@ regardless of job outcome.
 
 #### Get Noticed
 
-This is related to having a portfolio, and cold out-reach, but a technique
-that has worked for me in finding jobs is simply doing something a company
-is already trying to do, just better. For example, you could re-build an app
-or a screen from an app, post it on GitHub and Tweet it (nicely) at the original
-company as a way of potentially catching attention both from the original
-company, or others in the Flutter community.
+This is related to having a portfolio, and cold out-reach, but a technique that
+has worked for me in finding jobs is simply doing something a company is already
+trying to do, just better. For example, you could re-build an app or a screen
+from an app, post it on GitHub and Tweet it (nicely) at the original company as
+a way of potentially catching attention both from the original company, or
+others in the Flutter community.
 
 From the company's perspective, if they're considering hiring, you've already
 dramatically de-risked yourself. You clearly want to work on what they're
 working on, and you have the skills to do it. So long as you were nice about
-your outreach, you're also demonstrating your communication ability and
-ability to present your self. Win, Win, Win.
+your outreach, you're also demonstrating your communication ability and ability
+to present your self. Win, Win, Win.
 
 As with earlier discussions, I would encourage you to engage in any such
 exercise _for you_. There is a low chance the company will be hiring at that
@@ -172,9 +172,9 @@ In terms of posting jobs, my suggestions are similar to the above:
 1. Mention Flutter. A lot of devs _want_ to work with Flutter, if you want to
    hire Flutter-aware devs or are at least considering Flutter as a possible
    technology, mention it.
-2. Get your job on the web. A publicly-accessible URL is key (and may be
-   legally required for some jobs), if you have that (and not buried behind
-   sign-in, etc.) others can share it.
+2. Get your job on the web. A publicly-accessible URL is key (and may be legally
+   required for some jobs), if you have that (and not buried behind sign-in,
+   etc.) others can share it.
 3. Get your network to share it! LinkedIn is great, but there are millions of
    Flutter devs, and most are not on LinkedIn. https://flutter.dev/community
    lists some Slack channels and Discord channels. You can also simply tweet at

--- a/src/content/blog/how-we-built-code-push.md
+++ b/src/content/blog/how-we-built-code-push.md
@@ -1,32 +1,34 @@
 ---
 title: How we built Flutter code push
 author: eseidel
-description: Walk through of the changes made to Dart and Flutter in order to make code push work.
+description:
+  Walk through of the changes made to Dart and Flutter in order to make code
+  push work.
 date: 2024-05-17
 cover: how-we-built-code-push-cover.png
 ---
 
 One of the most common questions we get, is "how does Shorebird work?". This
 article describes some of the changes we made to Dart and Flutter in order to
-make code push work. If you have more questions, [send us an
-email](mailto:contact@shorebird.dev) or [ask on
-Discord](https://discord.gg/shorebird) and we’ll be happy to answer them or
-include them in a future article.
+make code push work. If you have more questions,
+[send us an email](mailto:contact@shorebird.dev) or
+[ask on Discord](https://discord.gg/shorebird) and we’ll be happy to answer them
+or include them in a future article.
 
 ## Code Push
 
 Code push, sometimes called "over the air updates", is a way of updating
 application code in production so that all your users are always running the
-latest code – just like how a web application works. [Code push for
-Flutter](https://github.com/flutter/flutter/issues/14330) is one of the top 50
-most upvoted issues across all of GitHub. Code push is a helpful tool to allow
-developers to push small updates to their applications without having to force
-all your users to download a new version of your app.
+latest code – just like how a web application works.
+[Code push for Flutter](https://github.com/flutter/flutter/issues/14330) is one
+of the top 50 most upvoted issues across all of GitHub. Code push is a helpful
+tool to allow developers to push small updates to their applications without
+having to force all your users to download a new version of your app.
 
 This blog takes a closer look at how we built a custom Dart toolchain and
 runtime to make apps updatable in production. For more information on the
-architecture of Shorebird Code Push, [check out our
-docs](https://docs.shorebird.dev/architecture/).
+architecture of Shorebird Code Push,
+[check out our docs](https://docs.shorebird.dev/architecture/).
 
 ## How Does Code Push Work?
 
@@ -66,8 +68,8 @@ not use Dart’s JIT. Instead we use a custom interpreter we built. An
 [interpreter](<https://en.wikipedia.org/wiki/Interpreter_(computing)>) is code
 that is used to execute logic from source code directly, without "compiling" it
 (translating it to machine code). This is important in the context of updates,
-because use of an interpreter is required by [Apple’s developer
-agreement](https://developer.apple.com/support/terms/apple-developer-program-license-agreement/#b331)
+because use of an interpreter is required by
+[Apple’s developer agreement](https://developer.apple.com/support/terms/apple-developer-program-license-agreement/#b331)
 when updating applications. Dart did not have a production-ready interpreter,
 but was designed in such a way that adding one was possible, so we did.
 
@@ -97,8 +99,8 @@ enabled what Shorebird has done.
 Functions within a JIT runtime need to be aware they could have different
 compiled representations (e.g. one simple compile and one later optimized
 compile for the same function). Shorebird takes advantage of this quirk of
-Dart’s architecture to insert a new interpreter as an alternative mechanism
-for a function to use to execute. This allows us to effectively replace parts of
+Dart’s architecture to insert a new interpreter as an alternative mechanism for
+a function to use to execute. This allows us to effectively replace parts of
 your application at runtime without needing to compile new code on the device.
 
 ## Building a Custom Interpreter for Dart
@@ -126,11 +128,10 @@ was hard. To do this we invented a new phase of Dart compilation we called the
 "linker". The linker’s job is to analyze two (similar) Dart programs and find
 the maximal similarity between them and then decide what would be necessary to
 update in the first one in order to make it run like the second. We still have a
-[couple missing
-optimizations](https://github.com/shorebirdtech/shorebird/issues/1892) in this
-part of our system, but when it works well, developers see 99% of their code run
-on the CPU (even for large changes). Teaching the linker how to figure this out
-however required significant changes to Dart’s compiler toolchain.
+[couple missing optimizations](https://github.com/shorebirdtech/shorebird/issues/1892)
+in this part of our system, but when it works well, developers see 99% of their
+code run on the CPU (even for large changes). Teaching the linker how to figure
+this out however required significant changes to Dart’s compiler toolchain.
 
 ## Changes to Dart’s Toolchain
 
@@ -159,8 +160,8 @@ hold constant references used within that function (e.g. strings, integers).
 Dart’s AOT combines all of these "Object Pools" into one global object pool and
 updates all parts of your program accordingly to reference slots in this global
 object pool. Objects in this pool are referenced by index, so the string "hello"
-mentioned above might be at index 1234 in the object pool and thus code
-compiled for your program would reference "hello" by the number 1234.
+mentioned above might be at index 1234 in the object pool and thus code compiled
+for your program would reference "hello" by the number 1234.
 
 So why does this matter? This matters because when we’re trying to update your
 program if the new version of your code uses new constants (a very common
@@ -228,6 +229,6 @@ your app in only a few minutes – with _no code changes required_.
 Shorebird is free to use for small applications, with
 [pricing](https://shorebird.dev/#pricing) that scales with your business needs.
 
-Learn more at our website: https://shorebird.dev. See most of our source code
-on GitHub: https://github.com/shorebirdtech/shorebird. If you ever have
-questions, our entire team is on Discord: https://discord.gg/shorebird.
+Learn more at our website: https://shorebird.dev. See most of our source code on
+GitHub: https://github.com/shorebirdtech/shorebird. If you ever have questions,
+our entire team is on Discord: https://discord.gg/shorebird.

--- a/src/content/blog/improved-patch-delivery.md
+++ b/src/content/blog/improved-patch-delivery.md
@@ -1,7 +1,8 @@
 ---
 title: Improved Patch Delivery
 author: felangel
-description: Announcing improved global patch delivery, availability, and performance.
+description:
+  Announcing improved global patch delivery, availability, and performance.
 date: 2024-09-05
 cover: improved-patch-delivery-cover.png
 ---

--- a/src/content/blog/ios-beta.md
+++ b/src/content/blog/ios-beta.md
@@ -20,19 +20,19 @@ stable version of Flutter (`3.16.9`).
 
 ## 🚀 Get Started
 
-Get started now with our [Quick Start
-Guide](https://docs.shorebird.dev/guides/code_push_quickstart) and join the
-Shorebird community on [Discord](https://discord.gg/shorebird)!
+Get started now with our
+[Quick Start Guide](https://docs.shorebird.dev/guides/code_push_quickstart) and
+join the Shorebird community on [Discord](https://discord.gg/shorebird)!
 
 ## 🚦 Status
 
 Code Push for iOS is now beta and safe for production apps. If you've been
 waiting to try Shorebird until there was stable iOS support, now is the time!
 
-If you encounter any problems, [please file an
-issue](https://github.com/shorebirdtech/shorebird/issues/new/choose) or reach
-out over [Discord](https://discord.gg/shorebird) we will work with you to
-address it immediately!
+If you encounter any problems,
+[please file an issue](https://github.com/shorebirdtech/shorebird/issues/new/choose)
+or reach out over [Discord](https://discord.gg/shorebird) we will work with you
+to address it immediately!
 
 ## 🔥 iOS improvements from alpha
 
@@ -60,9 +60,9 @@ patched and unpatched.
 
 ## 🐦 Try Shorebird
 
-Please [try adding Shorebird to your
-app](https://docs.shorebird.dev/guides/code_push_quickstart) on iOS and let us
-know what you think!
+Please
+[try adding Shorebird to your app](https://docs.shorebird.dev/guides/code_push_quickstart)
+on iOS and let us know what you think!
 
 See you on [Discord](https://discord.gg/shorebird) 👋
 

--- a/src/content/blog/macos-beta.md
+++ b/src/content/blog/macos-beta.md
@@ -27,5 +27,5 @@ shorebird patch macos --release-version=1.2.3+4
 
 As always, we want your feedback! We'd love for you to try this out and let us
 know what you think. Let us know if you run into any issues or have ideas for
-new features by [creating a new GitHub
-issue](https://github.com/shorebirdtech/shorebird/issues/new/choose)
+new features by
+[creating a new GitHub issue](https://github.com/shorebirdtech/shorebird/issues/new/choose)

--- a/src/content/blog/organizations.md
+++ b/src/content/blog/organizations.md
@@ -1,7 +1,8 @@
 ---
 title: Using Shorebird with your Team
 author: shorebirdtech
-description: Announcing "Organizations" support for improved collaboration within teams
+description:
+  Announcing "Organizations" support for improved collaboration within teams
 date: 2024-10-10
 cover: organizations-cover.png
 ---
@@ -15,13 +16,14 @@ and Google store policies._
 
 Shorebird Pro subscribers have long enjoyed per-app collaboration, where they
 were able to share a single app with multiple other developers. However until
-today it was not possible to share groups of apps to groups of people all at once. Nor was it
-possible to set up sharing without having apps in the first place. To address
-both of these, we've introduced "Organizations" support in Shorebird.
+today it was not possible to share groups of apps to groups of people all at
+once. Nor was it possible to set up sharing without having apps in the first
+place. To address both of these, we've introduced "Organizations" support in
+Shorebird.
 
-Your team can now collaborate on a group of apps together, and control access
-to that group of apps in a single place. It's also now possible to have the
-person who sets up billing and access for an organization be separate from the
-person who creates the apps.
+Your team can now collaborate on a group of apps together, and control access to
+that group of apps in a single place. It's also now possible to have the person
+who sets up billing and access for an organization be separate from the person
+who creates the apps.
 
 See our docs for more information: https://docs.shorebird.dev/orgs/

--- a/src/content/blog/patch-rollback.md
+++ b/src/content/blog/patch-rollback.md
@@ -16,16 +16,16 @@ and Google store policies._
 Shorebird already has many systems in place to make sure your patches are always
 improving your app for users. This includes providing you with
 [staging](https://docs.shorebird.dev/guides/staging-patches/) and testing
-facilities for your own QA, [on-device
-automatic-rollback](https://docs.shorebird.dev/architecture/) if a patch fails
-to load, and patch-install failure reporting. Until now, it has been possible to
-disable new installs of patches, or send new patches to users. Today, it’s now
-possible to issue global roll-backs of patches to all users.
+facilities for your own QA,
+[on-device automatic-rollback](https://docs.shorebird.dev/architecture/) if a
+patch fails to load, and patch-install failure reporting. Until now, it has been
+possible to disable new installs of patches, or send new patches to users.
+Today, it’s now possible to issue global roll-backs of patches to all users.
 
 Patches made with Shorebird Flutter 3.22.3 or later support global rollback.
-Rollbacks can be initiated from the [Shorebird
-Console](https://console.shorebird.dev/). See our [rollback
-docs](https://docs.shorebird.dev/code-push/rollback/) for more info.
+Rollbacks can be initiated from the
+[Shorebird Console](https://console.shorebird.dev/). See our
+[rollback docs](https://docs.shorebird.dev/code-push/rollback/) for more info.
 
 There is no charge for the use of the rollback service, since a rollback is a
 patch removal rather than install. When rolling back from one patch to another,

--- a/src/content/blog/shorebird-code-push-v2.md
+++ b/src/content/blog/shorebird-code-push-v2.md
@@ -7,8 +7,7 @@ cover: code-push-v2-cover.png
 ---
 
 We're excited to announce a pre-release of version 2.0 of the
-[`shorebird_code_push`
-package](https://pub.dev/packages/shorebird_code_push/versions/2.0.0-dev.2).
+[`shorebird_code_push` package](https://pub.dev/packages/shorebird_code_push/versions/2.0.0-dev.2).
 
 The `shorebird_code_push` package is a completely optional package that allows
 developers to customize the user experience of downloading and installing over
@@ -27,8 +26,8 @@ Some common use cases for using `shorebird_code_push` are:
 ## What's New
 
 We've taken some time to re-imagine what the Dart API should look like when
-interfacing with the Shorebird updater and we've re-written the Dart API from the
-ground up.
+interfacing with the Shorebird updater and we've re-written the Dart API from
+the ground up.
 
 The two main areas we focused on were:
 
@@ -112,7 +111,8 @@ enum UpdateStatus {
 
 ### Performing Updates
 
-Finally, if an update is available you can use the `update` API to perform the update.
+Finally, if an update is available you can use the `update` API to perform the
+update.
 
 ```dart
 Future<void> _downloadUpdate() async {
@@ -129,10 +129,11 @@ Future<void> _downloadUpdate() async {
 }
 ```
 
-If the update was unsuccessful, you can now programmatically catch the `UpdateException`
-and have much more information about what went wrong.
+If the update was unsuccessful, you can now programmatically catch the
+`UpdateException` and have much more information about what went wrong.
 
-The `UpdateException` includes a human-readable `message` describing the error as well as an `UpdateFailureReason`:
+The `UpdateException` includes a human-readable `message` describing the error
+as well as an `UpdateFailureReason`:
 
 ```dart
 /// The reason a call to [ShorebirdUpdater.update] failed.
@@ -151,10 +152,10 @@ enum UpdateFailureReason {
 }
 ```
 
-To see the latest version in action, check out the [Shorebird Code Push
-Example](https://github.com/shorebirdtech/updater/tree/main/shorebird_code_push/example)
-or the [Flutter & Friends Conference
-App](https://github.com/felangel/flutter_and_friends).
+To see the latest version in action, check out the
+[Shorebird Code Push Example](https://github.com/shorebirdtech/updater/tree/main/shorebird_code_push/example)
+or the
+[Flutter & Friends Conference App](https://github.com/felangel/flutter_and_friends).
 
 ## Get Started
 
@@ -168,5 +169,5 @@ dependencies:
 ```
 
 We'd love to hear your feedback! If there's anything you'd like to see adjusted
-or improved, please [let us know by filing an
-issue](https://github.com/shorebirdtech/updater/issues/new).
+or improved, please
+[let us know by filing an issue](https://github.com/shorebirdtech/updater/issues/new).

--- a/src/content/blog/shorebird-codemagic.md
+++ b/src/content/blog/shorebird-codemagic.md
@@ -11,7 +11,8 @@ We're very excited to announce that we've been working with the folks at
 directly integrated into Codemagic's CI/CD 🥳
 
 You can configure release and patch workflows directly within Codemagic's UI
-allowing you to integrate Code Push into your Flutter app with just a few clicks ✨
+allowing you to integrate Code Push into your Flutter app with just a few clicks
+✨
 
 Watch our full walkthrough below ↓
 

--- a/src/content/blog/simplified-pricing.md
+++ b/src/content/blog/simplified-pricing.md
@@ -33,19 +33,18 @@ want, and only get billed for what you use.
 
 ![Pro Plan](../../assets/blog/simplified-pricing/ProPlan.png)
 
-Customers can control their spending limit from the [Shorebird
-Console](https://console.shorebird.dev). Your spending limit defaults to $0 and
-we will automatically notify you via email once when you’re close to your limit
-and again when you’ve reached your limit.
+Customers can control their spending limit from the
+[Shorebird Console](https://console.shorebird.dev). Your spending limit defaults
+to $0 and we will automatically notify you via email once when you’re close to
+your limit and again when you’ve reached your limit.
 
 ![Usage Limit](../../assets/blog/simplified-pricing/UsageLimit.png)
 
 Existing Shorebird customers with “Hobby” or “Teams” will see no changes. You
 can keep your plan as it exists today, or you’re welcome to transition to this
-new usage-based billing at any time on the [Shorebird
-Console](https://console.shorebird.dev).
+new usage-based billing at any time on the
+[Shorebird Console](https://console.shorebird.dev).
 
 We made a bunch of improvements behind the scenes to make this happen. If you
 have any questions about billing, or would like to purchase Shorebird in a
-different way, please don’t hesitate to reach
-out at contact@shorebird.dev.
+different way, please don’t hesitate to reach out at contact@shorebird.dev.

--- a/src/content/blog/tom-joins-shorebird.md
+++ b/src/content/blog/tom-joins-shorebird.md
@@ -8,28 +8,53 @@ cover: tom-joins-shorebird-cover.png
 
 I’m excited to share that I’ve joined Shorebird!
 
-For me, this decision wasn’t just about the next step in my career. It was about doubling down on Flutter and multi-platform development.
+For me, this decision wasn’t just about the next step in my career. It was about
+doubling down on Flutter and multi-platform development.
 
 ## A Longstanding Passion for Flutter
 
-I’ve been involved in the Flutter community since 2019, starting during my time at BMW and later at Very Good Ventures. Over the years, I’ve seen Flutter grow from an ambitious new framework to a powerhouse for multi-platform development. I’ve worked with teams around the world pushing Flutter to its limits, helping scale production apps, and advocating for its potential to simplify and accelerate development across mobile, web, and desktop.
+I’ve been involved in the Flutter community since 2019, starting during my time
+at BMW and later at Very Good Ventures. Over the years, I’ve seen Flutter grow
+from an ambitious new framework to a powerhouse for multi-platform development.
+I’ve worked with teams around the world pushing Flutter to its limits, helping
+scale production apps, and advocating for its potential to simplify and
+accelerate development across mobile, web, and desktop.
 
-Through it all, my belief has only strengthened: multi-platform should be the standard for application development. Businesses and developers shouldn’t have to choose between performance, maintainability, and reach. Flutter has already proven that a single codebase can deliver beautiful, native experiences across platforms, and Shorebird is building the tools to push that even further.
+Through it all, my belief has only strengthened: multi-platform should be the
+standard for application development. Businesses and developers shouldn’t have
+to choose between performance, maintainability, and reach. Flutter has already
+proven that a single codebase can deliver beautiful, native experiences across
+platforms, and Shorebird is building the tools to push that even further.
 
 ## Why Shorebird?
 
-Right now, Shorebird is tackling one of the biggest pain points in mobile development—getting updates to users faster. With code push, developers can fix bugs and ship improvements instantly, without waiting for app store approvals. This alone is a game-changer, but it’s just the beginning of what Shorebird is building.
+Right now, Shorebird is tackling one of the biggest pain points in mobile
+development—getting updates to users faster. With code push, developers can fix
+bugs and ship improvements instantly, without waiting for app store approvals.
+This alone is a game-changer, but it’s just the beginning of what Shorebird is
+building.
 
-When the opportunity came to join a team focused on solving real-world developer challenges in the Flutter ecosystem, I knew I had to be part of it.
+When the opportunity came to join a team focused on solving real-world developer
+challenges in the Flutter ecosystem, I knew I had to be part of it.
 
 ## Staying in the Flutter Ecosystem
 
-The Flutter community has been an incredible place to be, and I wanted to stay in this space because I truly believe in its potential. Multi-platform development isn’t just a nice-to-have—it’s the best way to build apps. I’ve seen firsthand how Flutter enables teams to move faster, deliver high-quality experiences, and reach more users with less overhead.
+The Flutter community has been an incredible place to be, and I wanted to stay
+in this space because I truly believe in its potential. Multi-platform
+development isn’t just a nice-to-have—it’s the best way to build apps. I’ve seen
+firsthand how Flutter enables teams to move faster, deliver high-quality
+experiences, and reach more users with less overhead.
 
-At Shorebird, I’ll focus on helping the company grow beyond engineering, encompassing product, sales, marketing, and operations, to provide these tools to as many Flutter developers as possible. The Shorebird team already includes some of the best minds in Flutter, and I’m excited to contribute to their vision.
+At Shorebird, I’ll focus on helping the company grow beyond engineering,
+encompassing product, sales, marketing, and operations, to provide these tools
+to as many Flutter developers as possible. The Shorebird team already includes
+some of the best minds in Flutter, and I’m excited to contribute to their
+vision.
 
 ## What’s Next?
 
-If you’re a Flutter developer, I’d love to connect and hear your thoughts on what you need to ship better apps, faster. Shorebird is just getting started, and there’s a lot of exciting work ahead.
+If you’re a Flutter developer, I’d love to connect and hear your thoughts on
+what you need to ship better apps, faster. Shorebird is just getting started,
+and there’s a lot of exciting work ahead.
 
 Let’s build the future of multi-platform development—together.

--- a/src/content/blog/tracks-percentage-rollouts-a-b-testing.md
+++ b/src/content/blog/tracks-percentage-rollouts-a-b-testing.md
@@ -6,10 +6,10 @@ date: 2024-11-14
 cover: tracks-cover.png
 ---
 
-Building on the success of our brand-new [`shorebird_code_push`
-package](https://pub.dev/packages/shorebird_code_push/versions/2.0.0) 2.0, we're
-announcing patch tracks, which can be used to support percentage-based
-rollouts and A/B testing within Shorebird.
+Building on the success of our brand-new
+[`shorebird_code_push` package](https://pub.dev/packages/shorebird_code_push/versions/2.0.0)
+2.0, we're announcing patch tracks, which can be used to support
+percentage-based rollouts and A/B testing within Shorebird.
 
 The `shorebird_code_push` package is a completely optional package that allows
 developers to customize the user experience of downloading and installing
@@ -23,21 +23,21 @@ able to offer patch rollout options that target specific users.
 
 However, with the updated package:shorebird_code_push, we've provided the API
 tools to make it easy for you to provide your own group-based control over who
-gets what updates when. With patch tracks, you can support QA testing, a
-public beta, or even for controlled percentage-based rollout across your
-userbase.
+gets what updates when. With patch tracks, you can support QA testing, a public
+beta, or even for controlled percentage-based rollout across your userbase.
 
 `ShorebirdUpdater` methods `checkForUpdate` and `update` now take an optional
-`track` parameter which affords you powerful control over app updates in the field.
+`track` parameter which affords you powerful control over app updates in the
+field.
 
 Examples of features it is now possible for you to add to your process:
 
 ### Group based update distribution
 
-The `shorebird` command line now takes a `--track` parameter which allows
-you to specify the track to send a patch to. For example, you can use
-`shorebird patch ios --track staging` to submit a patch to your iOS builds
-which is only available when requesting updates to the `staging` track.
+The `shorebird` command line now takes a `--track` parameter which allows you to
+specify the track to send a patch to. For example, you can use
+`shorebird patch ios --track staging` to submit a patch to your iOS builds which
+is only available when requesting updates to the `staging` track.
 
 This can be used for example to distribute updates only to your QA team for
 testing, which you can then later promote to the `stable` track for distribution
@@ -46,9 +46,9 @@ to all users.
 ### Percentage Rollouts
 
 Similar to groups, it is now possible to implement percentage rollouts of
-patches with Shorebird. Currently we do not provide UI for controlling
-rollouts, but rather the tools to allow customers to do so on
-their own. We've written a guide demonstrating how this can be accomplished:
+patches with Shorebird. Currently we do not provide UI for controlling rollouts,
+but rather the tools to allow customers to do so on their own. We've written a
+guide demonstrating how this can be accomplished:
 https://docs.shorebird.dev/guides/percentage-based-rollouts/
 
 ### A/B Testing
@@ -70,5 +70,5 @@ dependencies:
 ```
 
 We'd love to hear your feedback! If there's anything you'd like to see adjusted
-or improved, please [let us know by filing an
-issue](https://github.com/shorebirdtech/updater/issues/new).
+or improved, please
+[let us know by filing an issue](https://github.com/shorebirdtech/updater/issues/new).

--- a/src/content/blog/viewing-logs.md
+++ b/src/content/blog/viewing-logs.md
@@ -18,13 +18,13 @@ can also see logs for release apps without needing to attach a debugger?
 
 All Android system output can be viewed using the
 [`logcat`](https://developer.android.com/tools/logcat) command line tool. You
-can try this out by connecting your Android device via USB and running `adb
-logcat` in your terminal.
+can try this out by connecting your Android device via USB and running
+`adb logcat` in your terminal.
 
 Note: adb will need to be on your path for this to work. If you see an error
-like `command not found: adb` or `'adb' is not recognized as an internal or
-external command`, you will need to add `adb` to your PATH. StackOverflow has
-good answers to help with this for
+like `command not found: adb` or
+`'adb' is not recognized as an internal or external command`, you will need to
+add `adb` to your PATH. StackOverflow has good answers to help with this for
 [macOS/Linux](https://stackoverflow.com/questions/10303639/adb-command-not-found)
 and
 [Windows](https://stackoverflow.com/questions/20564514/adb-is-not-recognized-as-an-internal-or-external-command-operable-program-or)

--- a/src/content/blog/windows-beta.md
+++ b/src/content/blog/windows-beta.md
@@ -26,5 +26,5 @@ Windows support is in beta and only supports Windows x64 at this time. Let us
 know if you require Windows arm64 support.
 
 Try this out and let us know what you think. Let us know if you run into any
-issues or have ideas for new features by [creating a new GitHub
-issue](https://github.com/shorebirdtech/shorebird/issues/new/choose)
+issues or have ideas for new features by
+[creating a new GitHub issue](https://github.com/shorebirdtech/shorebird/issues/new/choose)

--- a/src/content/success-stories/easyspend.md
+++ b/src/content/success-stories/easyspend.md
@@ -1,6 +1,8 @@
 ---
 title: EasySpend
-description: Next generation fintech companies turn to cloud services like Shorebird to help them easily deploy and stay up to date across all of their platforms.
+description:
+  Next generation fintech companies turn to cloud services like Shorebird to
+  help them easily deploy and stay up to date across all of their platforms.
 date: 2025-03-07
 cover: easyspend-cover.png
 highlights: ['Over 1,000 monthly active users']
@@ -8,28 +10,57 @@ highlights: ['Over 1,000 monthly active users']
 
 <!-- cSpell:ignore easyspend -->
 
-EasySpend is a next-generation fintech company based in Lagos, Nigeria, with a mission to transform financial transactions for individuals and businesses. Offering a suite of services including virtual cards, bill payments, and seamless NGN-USD transactions, EasySpend is solving some of Africa’s biggest financial challenges. From providing reliable virtual dollar cards for freelancers and remote workers to enabling businesses with bulk payment solutions, EasySpend is redefining how people move money.
+EasySpend is a next-generation fintech company based in Lagos, Nigeria, with a
+mission to transform financial transactions for individuals and businesses.
+Offering a suite of services including virtual cards, bill payments, and
+seamless NGN-USD transactions, EasySpend is solving some of Africa’s biggest
+financial challenges. From providing reliable virtual dollar cards for
+freelancers and remote workers to enabling businesses with bulk payment
+solutions, EasySpend is redefining how people move money.
 
-In creating the mobile applications for EasySpend they turned to Flutter to ensure that their customer base of over 100,000 active users have a consistent experience no matter what device they are using. For many Flutter developers, targeting multiple platforms is a key advantage of the framework. However, building and deploying iOS apps typically requires access to macOS, creating a barrier for developers who don’t own a Mac. This was the challenge faced by the team at EasySpend.
+In creating the mobile applications for EasySpend they turned to Flutter to
+ensure that their customer base of over 100,000 active users have a consistent
+experience no matter what device they are using. For many Flutter developers,
+targeting multiple platforms is a key advantage of the framework. However,
+building and deploying iOS apps typically requires access to macOS, creating a
+barrier for developers who don’t own a Mac. This was the challenge faced by the
+team at EasySpend.
 
-> Being able to deploy to iOS without all of our developers using Mac’s removes a significant hurdle for many developers like us
+> Being able to deploy to iOS without all of our developers using Mac’s removes
+> a significant hurdle for many developers like us
 >
 > - David Sylvester-Paul, CTO at EasySpend
 
 **A Fully Remote Flutter Workflow**
 
-By using services including Shorebird, David Sylvester-Paul, CTO at EasySpend, and his team have been able to deploy their Flutter application to iOS devices without all developers on their team owning a Mac. By leveraging Shorebird’s capabilities alongside other cloud-based tools, they bypassed the traditional Apple development constraints and successfully shipped their app across all the platforms that their customers are using.
+By using services including Shorebird, David Sylvester-Paul, CTO at EasySpend,
+and his team have been able to deploy their Flutter application to iOS devices
+without all developers on their team owning a Mac. By leveraging Shorebird’s
+capabilities alongside other cloud-based tools, they bypassed the traditional
+Apple development constraints and successfully shipped their app across all the
+platforms that their customers are using.
 
 **Seamless Multi-Platform Deployment**
 
-By spending the engineering effort to integrate Codemagic with Shorebird they were able to create a mobile CI/CD pipeline that automatically pushes new builds, delivers patches, and significantly reduces deployment time. With all of this they have the flexibility to push out app changes on their schedule to ensure they are hitting their business objectives and customer needs.
+By spending the engineering effort to integrate Codemagic with Shorebird they
+were able to create a mobile CI/CD pipeline that automatically pushes new
+builds, delivers patches, and significantly reduces deployment time. With all of
+this they have the flexibility to push out app changes on their schedule to
+ensure they are hitting their business objectives and customer needs.
 
-> In the past, we often wondered how other highly rated mobile apps updated their features without forcing users to manually download an update from the store. That curiosity led us to Shorebird, and ever since, we have implemented it in all of our applications
+> In the past, we often wondered how other highly rated mobile apps updated
+> their features without forcing users to manually download an update from the
+> store. That curiosity led us to Shorebird, and ever since, we have implemented
+> it in all of our applications
 >
 > - David Sylvester-Paul, CTO at EasySpend
 
-With this approach, EasySpend supports multiple platforms—including iOS and Android—without over investing in cost prohibitive Apple hardware for an entire development team. This not only reduces development costs but also empowers more developers worldwide to build and distribute apps freely.
+With this approach, EasySpend supports multiple platforms—including iOS and
+Android—without over investing in cost prohibitive Apple hardware for an entire
+development team. This not only reduces development costs but also empowers more
+developers worldwide to build and distribute apps freely.
 
-> Shorebird made the process seamless, allowing me to focus on building great apps rather than worrying about hardware limitations.
+> Shorebird made the process seamless, allowing me to focus on building great
+> apps rather than worrying about hardware limitations.
 >
 > - David Sylvester-Paul, CTO at EasySpend

--- a/src/content/success-stories/junglee-games.md
+++ b/src/content/success-stories/junglee-games.md
@@ -1,39 +1,76 @@
 ---
 title: Junglee Games
-description: To be able to deliver seamless gaming, even at scale, Junglee Games is able to boost their apps reliability with Shorebird.
+description:
+  To be able to deliver seamless gaming, even at scale, Junglee Games is able to
+  boost their apps reliability with Shorebird.
 date: 2025-04-02
 cover: junglee-games-cover.png
 highlights:
   [
-    'Over 1M+ daily active users across Junglee Games applications utilizing Shorebird',
+    'Over 1M+ daily active users across Junglee Games applications utilizing
+    Shorebird',
     'Typically 2M+ patch installs via Shorebird each month',
   ]
 ---
 
-Junglee Games, a leader in the real money gaming industry, has consistently delivered engaging experiences to millions of users across the country. With flagship products like rummy, poker, and fantasy sports apps, they are at the forefront of the mobile gaming sector. To maintain their competitive edge, Junglee Games turned to Shorebird to enhance their app deployment and patching capabilities.
+Junglee Games, a leader in the real money gaming industry, has consistently
+delivered engaging experiences to millions of users across the country. With
+flagship products like rummy, poker, and fantasy sports apps, they are at the
+forefront of the mobile gaming sector. To maintain their competitive edge,
+Junglee Games turned to Shorebird to enhance their app deployment and patching
+capabilities.
 
 **Moving fast for changing requirements**
 
-Facing the challenge of rapid feature deployment and bug fixes, especially during high-traffic events like the Indian Premier League (IPL), Junglee Games needed a solution that would allow them to quickly address live issues without disrupting the user experience. Their existing processes required full app rollouts, which over time became a blocking issue in their deployment flow.
+Facing the challenge of rapid feature deployment and bug fixes, especially
+during high-traffic events like the Indian Premier League (IPL), Junglee Games
+needed a solution that would allow them to quickly address live issues without
+disrupting the user experience. Their existing processes required full app
+rollouts, which over time became a blocking issue in their deployment flow.
 
-Full app rollouts require a submission and review from the app stores, which is not a predictable process, even for small bug fixes. This meant that critical issues that were affecting users would end up facing launch delays. As a competitive game, it's a requirement that all users are using the same code, a level playing field, regardless of the platform or whether their device has automatically updated their app that day. This made the waiting game with the review even harder for them to manage.
+Full app rollouts require a submission and review from the app stores, which is
+not a predictable process, even for small bug fixes. This meant that critical
+issues that were affecting users would end up facing launch delays. As a
+competitive game, it's a requirement that all users are using the same code, a
+level playing field, regardless of the platform or whether their device has
+automatically updated their app that day. This made the waiting game with the
+review even harder for them to manage.
 
 **Shorebird Integration and Results**
 
-Junglee Games discovered Shorebird shortly after its launch and quickly integrated it into their Android platform. This integration enabled them to deploy over-the-air patches swiftly, reducing the time to address live issues from hours or days to mere minutes. The ability to control patch rollouts and deploy to limited sets of users for internal testing further streamlined their testing and deployment process.
+Junglee Games discovered Shorebird shortly after its launch and quickly
+integrated it into their Android platform. This integration enabled them to
+deploy over-the-air patches swiftly, reducing the time to address live issues
+from hours or days to mere minutes. The ability to control patch rollouts and
+deploy to limited sets of users for internal testing further streamlined their
+testing and deployment process.
 
-> With Shorebird OTA updates we are sure that if a user is launching the app that they have the latest patch and fixes available.
+> With Shorebird OTA updates we are sure that if a user is launching the app
+> that they have the latest patch and fixes available.
 >
 > - Bhavesh Patel, Associate Director of Engineering at Junglee Games
 
-With Shorebird, Junglee Games achieved remarkable improvements in their deployment strategy:
+With Shorebird, Junglee Games achieved remarkable improvements in their
+deployment strategy:
 
-- **Rapid Deployment** - During the IPL season, they successfully deployed 18-20 releases in just 2-3 months, handling a 5x increase in traffic seamlessly.
-- **Enhanced User Experience** - The OTA capabilities allowed them to quickly fix live issues, ensuring minimal disruption to their vast user base.
-- **Efficient Resource Utilization** - By maintaining a single codebase for multiple products and leveraging Shorebird’s patching capabilities, Junglee Games significantly reduced development time and resource allocation especially in the testing and release phase.
+- **Rapid Deployment** - During the IPL season, they successfully deployed 18-20
+  releases in just 2-3 months, handling a 5x increase in traffic seamlessly.
+- **Enhanced User Experience** - The OTA capabilities allowed them to quickly
+  fix live issues, ensuring minimal disruption to their vast user base.
+- **Efficient Resource Utilization** - By maintaining a single codebase for
+  multiple products and leveraging Shorebird’s patching capabilities, Junglee
+  Games significantly reduced development time and resource allocation
+  especially in the testing and release phase.
 
-Junglee Games’ partnership with Shorebird has been a game changer for their product, allowing them to maintain their position as a leader in the real money gaming industry. By embracing Shorebird’s solutions, they continue to deliver exceptional gaming experiences to their users, setting a benchmark for agility and efficiency in app deployment.
+Junglee Games’ partnership with Shorebird has been a game changer for their
+product, allowing them to maintain their position as a leader in the real money
+gaming industry. By embracing Shorebird’s solutions, they continue to deliver
+exceptional gaming experiences to their users, setting a benchmark for agility
+and efficiency in app deployment.
 
-> After integrating Shorebird into our release flow we no longer were afraid to experiment with features in our application. If an issue arises you can just rollback a patch easily instead of having to rush an emergency fix out the door.
+> After integrating Shorebird into our release flow we no longer were afraid to
+> experiment with features in our application. If an issue arises you can just
+> rollback a patch easily instead of having to rush an emergency fix out the
+> door.
 >
 > - Bhavesh Patel, Associate Director of Engineering at Junglee Games

--- a/src/content/success-stories/kijiji.md
+++ b/src/content/success-stories/kijiji.md
@@ -1,38 +1,72 @@
 ---
 title: Kijiji
-description: The leading Canadian online marketplace turned to Shorebird to ensure their customer base was up to date all the time.
+description:
+  The leading Canadian online marketplace turned to Shorebird to ensure their
+  customer base was up to date all the time.
 date: 2025-03-06
 cover: kijiji-cover.png
 highlights:
   [
     'Over 10 Million active users of the Kijiji mobile apps worldwide',
     '12 Million+ Shorebird patches installed to users in 2024',
-    'Approximately 68 days of review time saved in application deployment in 2024 by using Shorebird',
+    'Approximately 68 days of review time saved in application deployment in
+    2024 by using Shorebird',
   ]
 ---
 
 <!-- cSpell:ignore dougall -->
 
-Kijiji, a leading Canadian online marketplace, has been connecting millions of users for over a decade. With a focus on buying and selling new and used items, Kijiji has grown to host many wide-ranging product sections and boast a diverse user base, from power users to occasional buyers. With a large, dedicated user base, it’s critical that Kijiji’s website and mobile app remain user-friendly and maintain a high level of quality.
+Kijiji, a leading Canadian online marketplace, has been connecting millions of
+users for over a decade. With a focus on buying and selling new and used items,
+Kijiji has grown to host many wide-ranging product sections and boast a diverse
+user base, from power users to occasional buyers. With a large, dedicated user
+base, it’s critical that Kijiji’s website and mobile app remain user-friendly
+and maintain a high level of quality.
 
 **Transition to Flutter**
 
-Transitioning from a native app to Flutter three years ago, Kijiji’s revamped app launch went well, but the need for rapid and reliable updates became apparent. This was critically important in order to quickly react to user feedback as they were adjusting to the redesigned Flutter app. Maintaining a rigid release schedule with phased rollouts added complexity to addressing these urgent needs. This led the engineering team to look for a new tool to help solve their issues.
+Transitioning from a native app to Flutter three years ago, Kijiji’s revamped
+app launch went well, but the need for rapid and reliable updates became
+apparent. This was critically important in order to quickly react to user
+feedback as they were adjusting to the redesigned Flutter app. Maintaining a
+rigid release schedule with phased rollouts added complexity to addressing these
+urgent needs. This led the engineering team to look for a new tool to help solve
+their issues.
 
 **Using Shorebird**
 
-Kijiji integrated Shorebird into their development & deployment process, primarily for emergency "break glass" situations and critical fixes. The integration was straightforward, thanks to a collaboration with the Shorebird team. Kijiji’s implementation of Shorebird enabled a smooth deployment process for all of their mobile products. Shorebird empowered Kijiji to address user feedback and bugs swiftly, without disrupting their phased rollout schedule.
+Kijiji integrated Shorebird into their development & deployment process,
+primarily for emergency "break glass" situations and critical fixes. The
+integration was straightforward, thanks to a collaboration with the Shorebird
+team. Kijiji’s implementation of Shorebird enabled a smooth deployment process
+for all of their mobile products. Shorebird empowered Kijiji to address user
+feedback and bugs swiftly, without disrupting their phased rollout schedule.
 
-> Our overall percentage of users running a buggy release is much lower after incorporating Shorebird into our deployment process. Rather than waiting on the stores to approve a release, and an operating system to actually execute an update, we can know that our fixes are rolling out the second that we push the button to deploy in Shorebird.
+> Our overall percentage of users running a buggy release is much lower after
+> incorporating Shorebird into our deployment process. Rather than waiting on
+> the stores to approve a release, and an operating system to actually execute
+> an update, we can know that our fixes are rolling out the second that we push
+> the button to deploy in Shorebird.
 >
 > - Scott MacDougall, Head of Engineering, Mobile at Kijiji
 
 **Results**
 
-The adoption of Shorebird has been transformative for Kijiji’s mobile app teams. The platform acts as a "code push insurance policy," allowing for rapid resolution of critical issues. This ability has minimized potential revenue losses and enhanced user experience. The current integration with Shorebird has solidified their app's stability and performance, which has allowed their Play Store rating to rise to 4.5 stars.
+The adoption of Shorebird has been transformative for Kijiji’s mobile app teams.
+The platform acts as a "code push insurance policy," allowing for rapid
+resolution of critical issues. This ability has minimized potential revenue
+losses and enhanced user experience. The current integration with Shorebird has
+solidified their app's stability and performance, which has allowed their Play
+Store rating to rise to 4.5 stars.
 
-Kijiji's partnership with Shorebird exemplifies how strategic tech integration can safeguard revenue and improve user satisfaction. As Kijiji looks to the future, Shorebird remains a pivotal part of their development strategy, ensuring they can continue to serve their vast user base effectively.
+Kijiji's partnership with Shorebird exemplifies how strategic tech integration
+can safeguard revenue and improve user satisfaction. As Kijiji looks to the
+future, Shorebird remains a pivotal part of their development strategy, ensuring
+they can continue to serve their vast user base effectively.
 
-> Over time, we have realized that we could Shorebird a fix quickly to all of our users, which made an enormous impact on customer satisfaction. That’s now become a default phrase in our development team, as it’s a great tool to have in our toolbox.
+> Over time, we have realized that we could Shorebird a fix quickly to all of
+> our users, which made an enormous impact on customer satisfaction. That’s now
+> become a default phrase in our development team, as it’s a great tool to have
+> in our toolbox.
 >
 > - Scott MacDougall, Head of Engineering, Mobile at Kijiji

--- a/src/content/success-stories/push-press.md
+++ b/src/content/success-stories/push-press.md
@@ -1,65 +1,88 @@
 ---
 title: PushPress
-description: Delivering updates faster across 1,500+ white-labeled apps powered by Shorebird
+description:
+  Delivering updates faster across 1,500+ white-labeled apps powered by
+  Shorebird
 date: 2025-04-21
 cover: pushpress-cover.png
 highlights:
   [
     '1,500+ white-labeled apps maintained through Shorebird',
-    '3,600+ releases and 100+ patches sent in just 4 months, saving over 100 days of release management time',
-    'Over 1/3 of PushPress customer base uses Shorebird for with their Branded App offering',
+    '3,600+ releases and 100+ patches sent in just 4 months, saving over 100
+    days of release management time',
+    'Over 1/3 of PushPress customer base uses Shorebird for with their Branded
+    App offering',
   ]
 ---
 
-PushPress builds modern, powerful software for gym owners to run their business and engage
-with their members. With branded mobile apps, scheduling tools, and seamless member
-management, [PushPress](https://www.pushpress.com) helps fitness professionals focus on what they do best—building
-strong communities.
+PushPress builds modern, powerful software for gym owners to run their business
+and engage with their members. With branded mobile apps, scheduling tools, and
+seamless member management, [PushPress](https://www.pushpress.com) helps fitness
+professionals focus on what they do best—building strong communities.
 
-PushPress is on a mission to make gym management simpler, and that means building great
-software for gym owners and their members. With over 1,500 customers of the [PushPress Branded App](https://www.pushpress.com/products/branded-member-app) white-labeled mobile apps, each customized for individual fitness businesses—PushPress was spending too much time maintaining and updating their Branded Apps. That all changed when they integrated Shorebird.
+PushPress is on a mission to make gym management simpler, and that means
+building great software for gym owners and their members. With over 1,500
+customers of the
+[PushPress Branded App](https://www.pushpress.com/products/branded-member-app)
+white-labeled mobile apps, each customized for individual fitness
+businesses—PushPress was spending too much time maintaining and updating their
+Branded Apps. That all changed when they integrated Shorebird.
 
 **The challenge of scaling white-labeled apps**
 
-PushPress provides gym owners with fully branded mobile apps. These apps let members book
-classes, make purchases, and engage with their gym community. But with each app requiring its
-own assets, configurations, and App Store approvals, the update process quickly became a
-bottleneck.
+PushPress provides gym owners with fully branded mobile apps. These apps let
+members book classes, make purchases, and engage with their gym community. But
+with each app requiring its own assets, configurations, and App Store approvals,
+the update process quickly became a bottleneck.
 
-“We were manually clicking through 30 app builds at a time,” said Allan Wright, Senior Mobile
-Developer at PushPress. “With over 1,500 Branded Apps, that could take up to two weeks to finish between all the other work and distractions.”
+“We were manually clicking through 30 app builds at a time,” said Allan Wright,
+Senior Mobile Developer at PushPress. “With over 1,500 Branded Apps, that could
+take up to two weeks to finish between all the other work and distractions.”
 
-This pain point became all too real when a bug introduced in a release caused calendar issues
-for gym owners—right before a long holiday weekend.
+This pain point became all too real when a bug introduced in a release caused
+calendar issues for gym owners—right before a long holiday weekend.
 
-“It ruined the calendar for a specific type of appointment across our apps,” said Wright. “I couldn’t fix it fast enough. That bug lit the fire to look for some kind of code push solution to be integrated into our release flow.”
+“It ruined the calendar for a specific type of appointment across our apps,”
+said Wright. “I couldn’t fix it fast enough. That bug lit the fire to look for
+some kind of code push solution to be integrated into our release flow.”
 
 **Fast, reliable updates with Shorebird**
 
-PushPress adopted Flutter in 2021 after a tough start with React Native. After completing the
-rewrite and getting it released across their customers they started investing more into the Flutter
-ecosystem and looking for partners. After that calendar bug, Shorebird was the next step in
-modernizing their mobile infrastructure.
+PushPress adopted Flutter in 2021 after a tough start with React Native. After
+completing the rewrite and getting it released across their customers they
+started investing more into the Flutter ecosystem and looking for partners.
+After that calendar bug, Shorebird was the next step in modernizing their mobile
+infrastructure.
 
-> Our speed to release updates has skyrocketed. It used to take four days to two weeks depending on urgency. Now it’s way faster. The reliability of shipping fixes is night and day.
+> Our speed to release updates has skyrocketed. It used to take four days to two
+> weeks depending on urgency. Now it’s way faster. The reliability of shipping
+> fixes is night and day.
 >
 > - Allan Wright, Senior Mobile Developer at PushPress
 
-With Shorebird, PushPress can patch apps directly—without waiting on app store reviews or
-client action.
+With Shorebird, PushPress can patch apps directly—without waiting on app store
+reviews or client action.
 
-“Our job is to deliver value regardless of whether a gym owner has time to sign App Store
-documents,” said Wright. “With Shorebird, we can do that. Clients are thrilled they’re still getting new features and fixes without any extra work on their end.”
+“Our job is to deliver value regardless of whether a gym owner has time to sign
+App Store documents,” said Wright. “With Shorebird, we can do that. Clients are
+thrilled they’re still getting new features and fixes without any extra work on
+their end.”
 
 **Technical wins and team enthusiasm**
 
 Integrating Shorebird across PushPress’ three main apps—including their
-“Screens” App, which displays class attendance and gym workout information on a TV screen through the Amazon Fire Stick—wasn’t without challenges. With a complex codebase and pipeline already in place, and the need to keep the business running smoothly, the team needed to ensure zero downtime during the rollout. While it took some extra work to do that integration, the payoff has been worth it.
+“Screens” App, which displays class attendance and gym workout information on a
+TV screen through the Amazon Fire Stick—wasn’t without challenges. With a
+complex codebase and pipeline already in place, and the need to keep the
+business running smoothly, the team needed to ensure zero downtime during the
+rollout. While it took some extra work to do that integration, the payoff has
+been worth it.
 
-“It’s been really well received,” said Wright. “Especially by the folks who had to manually roll out
-those 1,200 apps before. They’re huge fans.”
+“It’s been really well received,” said Wright. “Especially by the folks who had
+to manually roll out those 1,200 apps before. They’re huge fans.”
 
-Today, PushPress is seeing rapid growth in Branded App adoption, with a high percentage of
-customers choosing to launch their own white-labeled experience.
+Today, PushPress is seeing rapid growth in Branded App adoption, with a high
+percentage of customers choosing to launch their own white-labeled experience.
 
-“We’ve had a lot of growth in Branded Apps since integrating Shorebird,” said Wright. “And it’s only going to get better from here.”
+“We’ve had a lot of growth in Branded Apps since integrating Shorebird,” said
+Wright. “And it’s only going to get better from here.”

--- a/src/content/success-stories/visible.md
+++ b/src/content/success-stories/visible.md
@@ -1,52 +1,90 @@
 ---
 title: Visible
-description: When dealing with mobile apps and hardware devices which always need to be in sync the team at Visible turned to Shorebird to help their release process go smoother.
+description:
+  When dealing with mobile apps and hardware devices which always need to be in
+  sync the team at Visible turned to Shorebird to help their release process go
+  smoother.
 date: 2025-04-01
 cover: visible-cover.png
 highlights:
   [
-    'Over 200,000 patches deployed to the Visible customer base over a 4 month period.',
-    '48 distinct patches created and deployed over 4 months resulting in over a month and a half of saved deployment time',
+    'Over 200,000 patches deployed to the Visible customer base over a 4 month
+    period.',
+    '48 distinct patches created and deployed over 4 months resulting in over a
+    month and a half of saved deployment time',
   ]
 ---
 
-Visible is on a mission to transform the way we understand and manage energy-limiting conditions like Long Covid and ME (Myalgic Encephalomyelitis). With over 100 million people around the world living with these illnesses, many have been left without recognition, support, or the tools they need to navigate their health.
-Founded by Harry Leeming, who developed Long Covid following a mild infection, Visible combines wearable technology and data science to make the invisible—visible. The platform empowers people living with chronic illness to measure and manage their symptoms, and contributes to research that can drive real change in healthcare.
+Visible is on a mission to transform the way we understand and manage
+energy-limiting conditions like Long Covid and ME (Myalgic Encephalomyelitis).
+With over 100 million people around the world living with these illnesses, many
+have been left without recognition, support, or the tools they need to navigate
+their health. Founded by Harry Leeming, who developed Long Covid following a
+mild infection, Visible combines wearable technology and data science to make
+the invisible—visible. The platform empowers people living with chronic illness
+to measure and manage their symptoms, and contributes to research that can drive
+real change in healthcare.
 
-> We’re building the tools for these conditions. For us, our doctors, researchers, and the world at large.
+> We’re building the tools for these conditions. For us, our doctors,
+> researchers, and the world at large.
 >
 > - Visible Team
 
 **The Challenge: Rapid Iteration in a High-Need Health Context**
 
-When you’re building technology for people managing chronic illness, responsiveness matters. The team at Visible moves quickly to learn from users, improve their product, and ship updates that make a real impact on people’s daily lives.
+When you’re building technology for people managing chronic illness,
+responsiveness matters. The team at Visible moves quickly to learn from users,
+improve their product, and ship updates that make a real impact on people’s
+daily lives.
 
-But the traditional app store release cycle made it hard to keep up with the needs of their customers.
+But the traditional app store release cycle made it hard to keep up with the
+needs of their customers.
 
-> We iterate quite quickly—sometimes with the intention to release weekly or a few times a month as we learn from our users. With store releases, we sometimes had to wait a few days to get the app to a testing track and then another week to get to production.
+> We iterate quite quickly—sometimes with the intention to release weekly or a
+> few times a month as we learn from our users. With store releases, we
+> sometimes had to wait a few days to get the app to a testing track and then
+> another week to get to production.
 >
 > - Dominik Roszkowski, Lead Engineer at Visible
 
-Beyond new features, quick bug fixes were equally important—especially in a health context where users depend on the app to track vital information.
+Beyond new features, quick bug fixes were equally important—especially in a
+health context where users depend on the app to track vital information.
 
-> As with every software product, there are bugs. These bug fixes have to go through the same approval flow as features which can slow down our response time.
+> As with every software product, there are bugs. These bug fixes have to go
+> through the same approval flow as features which can slow down our response
+> time.
 >
 > - Dominik Roszkowski, Lead Engineer at Visible
 
 **The Solution: Seamless Over-the-Air Updates with Shorebird**
 
-Visible integrated Shorebird into their CI pipeline to streamline their releases. With Shorebird, the team can push updates—both features and fixes—directly to users, bypassing the delays of traditional app store deployments.
+Visible integrated Shorebird into their CI pipeline to streamline their
+releases. With Shorebird, the team can push updates—both features and
+fixes—directly to users, bypassing the delays of traditional app store
+deployments.
 
-“Shorebird was a life changer for us,” said Roszkowski. “Now we can iterate much quicker. From the developer perspective, it’s really seamless. We created a set of CI jobs that makes publishing and patching with Shorebird incredibly easy.”
+“Shorebird was a life changer for us,” said Roszkowski. “Now we can iterate much
+quicker. From the developer perspective, it’s really seamless. We created a set
+of CI jobs that makes publishing and patching with Shorebird incredibly easy.”
 
-By having Shorebird as a new tool in their development toolbox the Engineering team at Visible is able to stay ahead of their customers needs. By combining their analytics that they already track in Mixpanel and Intercom they are able to react to customer issues in as close to real time as possible and allows them to see the delivery and adoption of their patches.
+By having Shorebird as a new tool in their development toolbox the Engineering
+team at Visible is able to stay ahead of their customers needs. By combining
+their analytics that they already track in Mixpanel and Intercom they are able
+to react to customer issues in as close to real time as possible and allows them
+to see the delivery and adoption of their patches.
 
-> Shorebird helped us tremendously and became a verb in our team—‘let’s shorebird it’ is a normal term for us now.
+> Shorebird helped us tremendously and became a verb in our team—‘let’s
+> shorebird it’ is a normal term for us now.
 >
 > - Dominik Roszkowski, Lead Engineer at Visible
 
 **The Impact: Speed, Reliability, and Empathy-Driven Development**
 
-With Shorebird, Visible can move at the pace of its mission. They’re delivering updates faster, addressing user needs more responsively, and avoiding the unnecessary delays around review cycles for simple fixes. That agility is essential when building tools for a medically under served population—especially when many team members are also patients themselves.
+With Shorebird, Visible can move at the pace of its mission. They’re delivering
+updates faster, addressing user needs more responsively, and avoiding the
+unnecessary delays around review cycles for simple fixes. That agility is
+essential when building tools for a medically under served population—especially
+when many team members are also patients themselves.
 
-Visible is more than a health tech startup—it’s a movement. And Shorebird helps them keep that movement in motion.
+Visible is more than a health tech startup—it’s a movement. And Shorebird helps
+them keep that movement in motion.

--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -8,22 +8,26 @@ description: Contact Shorebird
 
 ## 🛟 Support
 
-Filing an issue on [GitHub](https://github.com/shorebirdtech/shorebird/issues/new/choose) is the most direct to record the necessary information for us to help.
+Filing an issue on
+[GitHub](https://github.com/shorebirdtech/shorebird/issues/new/choose) is the
+most direct to record the necessary information for us to help.
 
 [Discord](https://discord.gg/shorebird) reaches our team via live chat.
 
-Paying Shorebird customers can access private support channels
-on Discord by messaging a Shorebird team member.
+Paying Shorebird customers can access private support channels on Discord by
+messaging a Shorebird team member.
 
 You're also welcome to [email us](mailto:contact@shorebird.dev).
 
 ## 🏷️ Sales
 
-[Email](mailto:contact@shorebird.dev) our sales team or [schedule a call](https://calendly.com/d/cmtb-j7m-qpb/shorebird-sales).
+[Email](mailto:contact@shorebird.dev) our sales team or
+[schedule a call](https://calendly.com/d/cmtb-j7m-qpb/shorebird-sales).
 
 ## 🐌 Mail
 
-Shorebird is globally remote, we have no physical office. Contracts or physical mail should use:
+Shorebird is globally remote, we have no physical office. Contracts or physical
+mail should use:
 
 ```
 2261 Market Street #5112

--- a/src/pages/jobs.md
+++ b/src/pages/jobs.md
@@ -27,8 +27,8 @@ very different from big companies and big teams.
 Working at a startup means:
 
 - Shipping. We ship 5 times a day, not 5 times a year.
-- (Growth)[https://www.paulgraham.com/growth.html]. We are trying to
-  grow quickly (revenues, customers, products, people, etc). Growth means
+- (Growth)[https://www.paulgraham.com/growth.html]. We are trying to grow
+  quickly (revenues, customers, products, people, etc). Growth means
   opportunity, variety and challenge.
 - Ambition. Hard work is needed and rewarded. Your colleagues are highly
   engaged, want to be here, want to work hard, and want to learn with and from
@@ -40,8 +40,8 @@ Working at a startup means:
   us is doing it. If you're going to do, you get to decide. Want to be our CDN
   expert or marketing expert or Dart compiler ninja? More than you could ever
   want to own, you will.
-- No layers. Direct access to customers. Direct access to management (the CEO
-  is the only manager). Nothing between you and direct action.
+- No layers. Direct access to customers. Direct access to management (the CEO is
+  the only manager). Nothing between you and direct action.
 - Few distractions. Engineers don't have meetings. There are no perf reviews. We
   show up and do.
 
@@ -62,9 +62,9 @@ I (and many others) tried to make the Web (PWAs, etc) solve "write once; run
 anywhere" a decade ago and failed. Hence we built Flutter to let Google and
 everyone write high-quality app experiences and have them go everywhere.
 
-Flutter is now the most popular solution for writing multi-platform apps. Over
-a million developers use Flutter every month, and growing. Flutter has proven
-that high-quality multi-platform is possible.
+Flutter is now the most popular solution for writing multi-platform apps. Over a
+million developers use Flutter every month, and growing. Flutter has proven that
+high-quality multi-platform is possible.
 
 However, still most apps don't use Flutter. And even some that do, sometimes
 struggle. Adopting Flutter can be challenging since the default offerings from
@@ -105,8 +105,8 @@ businesses behind them.
 
 ## Where we're at
 
-Shorebird incorporated January 2023. We've shipped our first product (code
-push) and now support around 2000 monthly active users, with about 300 paying
+Shorebird incorporated January 2023. We've shipped our first product (code push)
+and now support around 2000 monthly active users, with about 300 paying
 customers and strong growth. We raised several million dollars from a top-5 VC
 and great investors who care about our mission. We're not profitable yet, but
 have two years of cash on hand.
@@ -136,22 +136,22 @@ learning enterprise sales.
 
 The first hour or so every morning is spent working through the support queue
 which often results in small changes to the website, docs or code to avoid
-future customers hitting the same issues. The rest of the day is spent
-building. We have no meetings, no calendars, no perf reviews.
+future customers hitting the same issues. The rest of the day is spent building.
+We have no meetings, no calendars, no perf reviews.
 
 Most of the time we hang out on Discord video calls, but sometimes someone drops
-off to jam out to their music, get coffee or lunch, etc. We use the same
-Discord for private company chats and calls, private large-customer support
-channels, and our public community, which makes it very easy to talk to
-customers anytime we want to.
+off to jam out to their music, get coffee or lunch, etc. We use the same Discord
+for private company chats and calls, private large-customer support channels,
+and our public community, which makes it very easy to talk to customers anytime
+we want to.
 
 Engineers work across the whole stack. Our websites are in React (Astro), our
 backend and command-line tool are in Dart, our Database is postgres. We use
-Google Cloud, Redis and Cloudflare. We have our own fork of the Dart runtime
-and compiler (C++) and Flutter engine (C++) as well as an updater library (Rust)
-and a small Flutter package. Some of us prefer certain layers to others, but
-ideally you should want to work on most of the above and more as you help us add
-more products!
+Google Cloud, Redis and Cloudflare. We have our own fork of the Dart runtime and
+compiler (C++) and Flutter engine (C++) as well as an updater library (Rust) and
+a small Flutter package. Some of us prefer certain layers to others, but ideally
+you should want to work on most of the above and more as you help us add more
+products!
 
 3-4 times a year we all get together in person for a week. We occasionally
 attend meetups or fly to visit customers. Engineers aren't expected to attend
@@ -159,8 +159,8 @@ any meetings, Eric has several customer meetings a week (and sometimes per day).
 
 ## Learn more
 
-We're a default-public organization, we operate on a [public
-discord](https://discord.gg/shorebird), our
+We're a default-public organization, we operate on a
+[public discord](https://discord.gg/shorebird), our
 [source](https://github.com/shorebirdtech/) and
 [planning](https://github.com/orgs/shorebirdtech/projects) are public. We're an
 all remote, distributed team.
@@ -193,9 +193,9 @@ very much see what we're like without even needing to apply.
 # Founding Engineer
 
 We write the tools others will use to build Flutter apps, including the compiler
-used to build them and runtime used to execute them. The ideal candidate
-should have at least passing familiarity with the "lower" levels of our stack
-including using a systems-language (like C++) doing programming on mobile.
+used to build them and runtime used to execute them. The ideal candidate should
+have at least passing familiarity with the "lower" levels of our stack including
+using a systems-language (like C++) doing programming on mobile.
 
 ## Compensation
 
@@ -216,7 +216,8 @@ You
 - Live within in GMT-10 to GMT-3 (US timezones +/- 2)
 - Enjoy regularly learning/teaching yourself new skills
 - Want to work on a small, distributed team
-- Feel excited about our mission of making high-quality multi-platform the default
+- Feel excited about our mission of making high-quality multi-platform the
+  default
 - Like creating excellent developer experiences
 - Have experience building and shipping production software
 

--- a/src/pages/terms/index.md
+++ b/src/pages/terms/index.md
@@ -102,14 +102,14 @@ worldwide, royalty-free, license to use, reproduce, distribute, perform and
 display the Application and/or User Data solely for the purposes of providing
 the Services. You further agree Shorebird has the perpetual license and right to
 copy, analyze and use any of Your User Data solely in anonymized and aggregated
-format for Shorebird’s business purposes. For the avoidance of doubt,
-Shorebird will not; (i) reverse engineer, de-compile, translate, disassemble, or
-attempt to discover the source code of any Application or any part thereof; or
-(ii) distribute the Application or any part thereof to any third party other
-than solely as part of providing the Services. Shorebird does not pre-screen
-User Data, but Shorebird and its designee have the right (but not the
-obligation) in their sole discretion to refuse or remove any User Data that is
-available via the Services.
+format for Shorebird’s business purposes. For the avoidance of doubt, Shorebird
+will not; (i) reverse engineer, de-compile, translate, disassemble, or attempt
+to discover the source code of any Application or any part thereof; or (ii)
+distribute the Application or any part thereof to any third party other than
+solely as part of providing the Services. Shorebird does not pre-screen User
+Data, but Shorebird and its designee have the right (but not the obligation) in
+their sole discretion to refuse or remove any User Data that is available via
+the Services.
 
 ## E. License Grant and Restrictions While Using the Services.
 


### PR DESCRIPTION
## Status

**READY**

## Description

Attempted this in #285 but looks like many files needed updates so splitting it into its own PR.

This brings the same rules we have in `docs` and `handbook` over to this repo in order to keep things consistent.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
