### PR TITLE
feat: Add talk to sales url

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,14 +13,14 @@ export default defineConfig({
   },
   integrations: [react(), sitemap()],
   redirects: {
-    // Some old docs may still point to .html urls for terms and privacy.
-    '/terms.html': '/terms',
-    '/privacy.html': '/privacy',
     '/faq': 'https://docs.shorebird.dev/faq',
-    '/security': 'https://handbook.shorebird.dev/security',
-    '/workshops': 'https://calendly.com/felix-shorebird/shorebird-workshop',
     '/newsletter-signup': config.newsletterSubscriptionUrl,
+    '/privacy.html': '/privacy',
+    '/security': 'https://handbook.shorebird.dev/security',
     // Initially tweeted the wrong link:
     '/success-stories/pushpress/': '/success-stories/push-press',
+    '/talk-to-sales': config.contactSales,
+    '/terms.html': '/terms',
+    '/workshops': 'https://calendly.com/felix-shorebird/shorebird-workshop',
   },
 });


### PR DESCRIPTION
## Status

**READY**

## Description

Adding a `\talk-to-sales` vanity URL for use on socials. Also alphabetized the redirects list.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality
      to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
