### PR TITLE
feat: add custom newsletter signup form

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,7 +14,6 @@ export default defineConfig({
   integrations: [react(), sitemap()],
   redirects: {
     '/faq': 'https://docs.shorebird.dev/faq',
-    '/newsletter-signup': config.newsletterSubscriptionUrl,
     '/privacy.html': '/privacy',
     '/security': 'https://handbook.shorebird.dev/security',
     // Initially tweeted the wrong link:

--- a/src/components/home/callout.astro
+++ b/src/components/home/callout.astro
@@ -25,7 +25,7 @@ import config from '@/config';
           <Ellipse /> Try it now
         </GradientOutlineButton>
       </a>
-      <a href={config.newsletterSubscriptionUrl} class="w-full md:w-auto">
+      <a href="/newsletter-signup" class="w-full md:w-auto">
         <Button variant="outline" className="font-light w-full">
           Subscribe to our newsletter
         </Button>

--- a/src/pages/newsletter-signup.astro
+++ b/src/pages/newsletter-signup.astro
@@ -1,0 +1,154 @@
+---
+import config from '@/config';
+import MainLayout from '@/layouts/main.astro';
+import { Spacer } from '@/components/ui/spacer';
+import { LogoFull } from '@/components/logos/logo-full';
+---
+
+<MainLayout title={config.app}>
+    <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter,family=Open+Sans&display=swap');
+    </style>
+    <div class="mx-auto flex-col items-center justify-center gap-2 text-center">
+        <Spacer />
+        <LogoFull className="mx-auto flex-col items-center justify-center gap-2 text-center w-1/3" />
+        <Spacer />
+        <div class="newsletter-form-container">
+            <Spacer />
+               <p class="text-text-2">
+                We’re on a mission to make businesses successful with Flutter, and we’re thrilled to have you on board. 
+               </p>
+               <p class="text-text-2">
+                By signing up, you’ll be the first to know about new tools, updates, and insights to help you build and iterate faster.
+            </p>
+            <Spacer />
+            <form class="newsletter-form" action="https://app.loops.so/api/newsletter-form/clkle380400tojo0nmapdkds7" method="POST" style="display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%;"><input class="newsletter-form-input" name="newsletter-form-input" type="email" placeholder="you@example.com" required="" style="font-family: 'Open Sans', sans-serif; color: rgb(0, 0, 0); font-size: 16px; margin: 0px 0px 10px; width: 100%; max-width: 300px; min-width: 100px; background: rgb(255, 255, 255); border: 1px solid rgb(209, 213, 219); box-sizing: border-box; box-shadow: rgba(0, 0, 0, 0.05) 0px 1px 2px; border-radius: 6px; padding: 8px 12px;"><button type="submit" class="newsletter-form-button" style="background: rgb(34, 34, 34); font-size: 16px; color: rgb(255, 255, 255); font-family: 'Open Sans', sans-serif; display: flex; width: 100%; max-width: 300px; white-space: normal; height: 38px; align-items: center; justify-content: center; flex-direction: row; padding: 9px 17px; box-shadow: rgba(0, 0, 0, 0.05) 0px 1px 2px; border-radius: 6px; text-align: center; font-style: normal; font-weight: 500; line-height: 20px; border: medium; cursor: pointer;">Subscribe</button><button type="button" class="newsletter-loading-button" style="background: rgb(34, 34, 34); font-size: 16px; color: rgb(255, 255, 255); font-family: 'Open Sans', sans-serif; display: none; width: 100%; max-width: 300px; white-space: normal; height: 38px; align-items: center; justify-content: center; flex-direction: row; padding: 9px 17px; box-shadow: rgba(0, 0, 0, 0.05) 0px 1px 2px; border-radius: 6px; text-align: center; font-style: normal; font-weight: 500; line-height: 20px; border: medium; cursor: pointer;">Please wait...</button></form><div class="newsletter-success" style="display: none; align-items: center; justify-content: center; width: 100%;"><p class="newsletter-success-message" style="font-family: 'Open Sans', sans-serif; color: rgb(255, 255, 255); font-size: 14px;">Thanks! We'll be in touch!</p></div><div class="newsletter-error" style="display: none; align-items: center; justify-content: center; width: 100%;"><p class="newsletter-error-message" style="font-family: 'Open Sans', sans-serif; color: rgb(185, 28, 28); font-size: 14px;">Oops! Something went wrong, please try again</p></div>
+            <button 
+            class='newsletter-back-button'
+            type='button' 
+            style='color:#6b7280;font: 14px, Inter, sans-serif;margin:10px auto;text-align:center;display:none;background:transparent;border:none;cursor:pointer'
+            onmouseout='this.style.textDecoration="none"' 
+            onmouseover='this.style.textDecoration="underline"'>
+            &larr; Back
+            </button>
+            </div><script>
+            function submitHandler(event) {
+            event.preventDefault();
+            var container = event.target.parentNode;
+            var form = container.querySelector(".newsletter-form");
+            var formInput = container.querySelector(".newsletter-form-input");
+            var success = container.querySelector(".newsletter-success");
+            var errorContainer = container.querySelector(".newsletter-error");
+            var errorMessage = container.querySelector(".newsletter-error-message");
+            var backButton = container.querySelector(".newsletter-back-button");
+            var submitButton = container.querySelector(".newsletter-form-button");
+            var loadingButton = container.querySelector(".newsletter-loading-button");
+            
+            
+            const rateLimit = () => {
+                errorContainer.style.display = "flex";
+                errorMessage.innerText = "Too many signups, please try again in a little while";
+                submitButton.style.display = "none";
+                formInput.style.display = "none";
+                backButton.style.display = "block";
+            }
+            
+            // Compare current time with time of previous sign up
+            var time = new Date();
+            var timestamp = time.valueOf();
+            var previousTimestamp = localStorage.getItem("loops-form-timestamp");
+            
+            // If last sign up was less than a minute ago
+            // display error
+            if (previousTimestamp && Number(previousTimestamp) + 60000 > timestamp) {
+                rateLimit();
+                return;
+            }
+            localStorage.setItem("loops-form-timestamp", timestamp);
+            
+            submitButton.style.display = "none";
+            loadingButton.style.display = "flex";
+            
+            var formBody = "userGroup=newsletter-signup&mailingLists=&email=" 
+                + encodeURIComponent(formInput.value)
+                ;
+            
+            fetch(event.target.action, {
+                method: "POST",
+                body: formBody,
+                headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                },
+            })
+                .then((res) => [res.ok, res.json(), res])
+                .then(([ok, dataPromise, res]) => {
+                if (ok) {
+                    // If response successful
+                    // display success
+                    success.style.display = "flex";
+                    form.reset();
+                } else {
+                    // If response unsuccessful
+                    // display error message or response status
+                    dataPromise.then(data => {
+                    errorContainer.style.display = "flex";
+                    errorMessage.innerText = data.message
+                        ? data.message
+                        : res.statusText;
+                    });
+                }
+                })
+                .catch(error => {
+                // check for cloudflare error
+                if (error.message === "Failed to fetch") {
+                    rateLimit();
+                    return;
+                }
+                // If error caught
+                // display error message if available
+                errorContainer.style.display = "flex";
+                if (error.message) errorMessage.innerText = error.message;
+                localStorage.setItem("loops-form-timestamp", '');
+                })
+                .finally(() => {
+                formInput.style.display = "none";
+                loadingButton.style.display = "none";
+                backButton.style.display = "block";
+                });
+            }
+            function resetFormHandler(event) {
+            var container = event.target.parentNode;
+            var formInput = container.querySelector(".newsletter-form-input");
+            var success = container.querySelector(".newsletter-success");
+            var errorContainer = container.querySelector(".newsletter-error");
+            var errorMessage = container.querySelector(".newsletter-error-message");
+            var backButton = container.querySelector(".newsletter-back-button");
+            var submitButton = container.querySelector(".newsletter-form-button");
+            
+            success.style.display = "none";
+            errorContainer.style.display = "none";
+            errorMessage.innerText = "Oops! Something went wrong, please try again";
+            backButton.style.display = "none";
+            formInput.style.display = "flex";
+            submitButton.style.display = "flex";
+            }
+            
+            var formContainers = document.getElementsByClassName(
+            "newsletter-form-container"
+            );
+            
+            for (var i = 0; i < formContainers.length; i++) {
+            var formContainer = formContainers[i]
+            var handlersAdded = formContainer.classList.contains('newsletter-handlers-added')
+            if (handlersAdded) continue;
+            formContainer
+                .querySelector(".newsletter-form")
+                .addEventListener("submit", submitHandler);
+            formContainer
+                .querySelector(".newsletter-back-button")
+                .addEventListener("click", resetFormHandler);
+            formContainer.classList.add("newsletter-handlers-added");
+            }
+            </script>
+    </div>
+</MainLayout>


### PR DESCRIPTION
## Status

**READY**

## Description

In moving our marketing emails over to Loops we need to replace the old newsletter signup form with a new one. I removed the old path and reused it to make sure that links still work going forward. Overall just a very basic page but does submit direct to Loops with Source being Form and User Group being "newsletter-signup".

![CleanShot 2025-05-27 at 15 16 15](https://github.com/user-attachments/assets/1c5219f4-d192-4d07-98f7-c7bc5857eba4)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality
      to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
