### PR TITLE
fix: update blog news letter callout

### DIFF
--- a/src/components/blog/blog-callout.tsx
+++ b/src/components/blog/blog-callout.tsx
@@ -24,50 +24,22 @@ function BlogCallout() {
       </div>
       <div id="mc_embed_signup" className="mt-4">
         <form
-          action="https://dev.us21.list-manage.com/subscribe/post?u=782cd1f159c245fdb1a73bfb3&amp;id=f3a2318a39&amp;f_id=007fece1f0"
-          method="post"
+          action={config.newsletterSubscriptionUrl}
+          method="get"
           id="mc-embedded-subscribe-form"
           target="_self"
         >
-          <div className="mx-auto mb-3 max-w-screen-sm items-center gap-2 space-y-4 sm:flex sm:space-y-0">
-            <div className="relative w-full">
-              <label
-                htmlFor="mce-EMAIL"
-                className="text-text-2 mb-2 hidden text-sm font-medium"
-              >
-                Email address
-              </label>
-              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                <svg
-                  className="text-text-2 h-5 w-5"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"></path>
-                  <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"></path>
-                </svg>
-              </div>
-              <input
-                className="border-border-1 text-text-1 placeholder-text-text-2 block w-full rounded-lg border p-3 pl-10 text-sm md:rounded-lg"
-                placeholder="Subscribe to our newsletter"
-                type="email"
-                name="EMAIL"
-                id="mce-EMAIL"
-                autoComplete="email"
-                required={false}
-              />
-            </div>
+          <div className="mt-4 inline-block w-full px-4 py-2">
             <div>
               <Button
                 variant="outline"
-                className="w-full md:w-auto"
+                className="w-full"
                 id="mc-embedded-subscribe"
                 type="submit"
-                value="Subscribe"
+                value="Subscribe to our Newsletter"
                 name="subscribe"
               >
-                Subscribe
+                Subscribe to our Newsletter
               </Button>
               {/* real people should not fill this in and expect good things - do not remove this or risk form bot signups */}
               <div className="hidden" aria-hidden="true">


### PR DESCRIPTION
## Status

**READY**

## Description

Got missed in #301 as it wasn't using the config value and just had the raw URL. Updating it to just be a button like the main page of the site rather than a form as our basic form doesn't support that right now.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality
      to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
