### PR TITLE
feat: migrate jobs to content collection

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,4 +20,6 @@ export default {
   contactSales: 'https://calendly.com/d/cmtb-j7m-qpb/shorebird-sales',
   contactEmail: 'contact@shorebird.dev',
   complianceUrl: 'https://handbook.shorebird.dev/compliance',
+  handbookUrl: 'https://handbook.shorebird.dev',
+  hiringEmail: 'eric@shorebird.dev',
 };

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -34,7 +34,20 @@ const successStoriesCollection = defineCollection({
   }),
 });
 
+const jobsCollection = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/jobs' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    location: z.string(),
+    type: z.string(),
+    equity: z.boolean(),
+    draft: z.boolean().default(false),
+  }),
+});
+
 export const collections = {
   blog: blogCollection,
   successStories: successStoriesCollection,
+  jobs: jobsCollection,
 };

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -41,8 +41,6 @@ const jobsCollection = defineCollection({
     description: z.string(),
     location: z.string(),
     type: z.string(),
-    equity: z.boolean(),
-    draft: z.boolean().default(false),
   }),
 });
 

--- a/src/content/jobs/developer-relations-marketing-lead.md
+++ b/src/content/jobs/developer-relations-marketing-lead.md
@@ -1,31 +1,12 @@
 ---
-layout: '@/layouts/markdown.astro'
-title: Jobs
-description: Shorebird openings
+title: 'Developer Relations / Marketing Lead'
+description: 'Help us reach all Flutter developers.'
+location: 'Remote (North America)'
+type: 'Full-time or contract'
+equity: true
 ---
 
-## Open Positions
-
-- [Developer Relations / Marketing Lead](#developer-relations--marketing-lead)
-- [Full Stack Software Engineer](#full-stack-software-engineer)
-
----
-
-See [Shorebird's Public Handbook](https://handbook.shorebird.dev/) to learn more
-about us. Shorebird is a default-public company, so nearly everything is open.
-You're always welcome to lurk on our [Discord](https://discord.gg/shorebird),
-read our [GitHub issues/code/project plans](https://github.com/shorebirdtech),
-and [public company handbook](https://handbook.shorebird.dev/).
-
-### Developer Relations / Marketing Lead
-
-Location: Remote (North America)
-
-Type: Full-time or contract
-
-Equity: Yes — Early-stage ownership opportunity
-
-#### The problem
+### The problem
 
 Shorebird is building “the Flutter company”. Our founder started/led Flutter,
 and now we’re building a company to drive Flutter forward, even if Google
@@ -39,7 +20,7 @@ craft our story and tell it widely. You love talking to developers, you love
 writing content, giving talks etc and you’ll have full support to do what it
 takes to raise awareness.
 
-#### What You’ll Do
+### What You’ll Do
 
 - Own marketing. From website content to email campaigns to positioning, you’ll
   shape how we tell the Shorebird story.
@@ -64,7 +45,7 @@ takes to raise awareness.
 - Close the loop. Bring insights from the community back to the team to inform
   product direction.
 
-#### What We’re Looking For
+### What We’re Looking For
 
 - Mission alignment. You care about helping the world stop writing everything
   twice. Flutter is our tool for that and Shorebird aims to take Flutter beyond
@@ -91,73 +72,11 @@ takes to raise awareness.
 - Bonus: experience in startups, open-source communities, or the Flutter
   ecosystem.
 
-#### Why Join
+### Why Join
 
 - Work directly with a small, senior team solving hard, high-impact problems.
 
 - Influence product, messaging, and strategy from the ground up.
-
-- Competitive compensation \+ early equity.
-
-- Shape the future of how mobile apps are built and shipped.
-
-### Full Stack Software Engineer
-
-Location: Remote (North America) or in-person (Chicago, New York City, or Palo
-Alto)
-
-Type: Full-time
-
-Equity: Yes — Early-stage ownership opportunity
-
-#### The problem
-
-We have one successful product with thousands of monthly users, delivering 10s
-of millions of updates around the globe, every month. We built this all with 2
-engineers. We also recently launched a second product. We simply need more
-engineers to keep up with our growing user base an ambition.
-
-#### What You’ll Do
-
-- Build and maintain backend infrastructure (mostly in Dart) that powers
-  developer tools used in production apps.
-
-- Contribute to our open source command line tools and native C++ code.
-
-- Own and ship features end-to-end, from our web UI to our backend APIs.
-
-- Help shape our culture, processes, and product direction.
-
-#### What We’re Looking For
-
-- Mission alignment. You care about helping the world stop writing everything
-  twice. Flutter is our tool for that and Shorebird aims to take Flutter beyond
-  where Google can.
-
-- Strong desire to work at a startup. We’re a tiny team. All remote. You’ll have
-  to want to make your own decisions and own them.
-
-- You're a strong generalist who can jump into unfamiliar systems and figure
-  things out.
-
-- You're a self-starter — you work well with little oversight and thrive in
-  ambiguous environments.
-
-- You’re excited about Flutter and want to help it succeed.
-
-- You care about product quality and developer experience.
-
-- You have solid experience with at least one part of the stack — cloud,
-  developer tools, or compilers/runtimes — and are eager to learn the rest.
-
-- Bonus: experience with build systems, deployment pipelines, or developer
-  tools.
-
-- Bonus: startup experience or contributions to open source projects.
-
-#### Why Join
-
-- Work directly with a small, senior team solving hard, high-impact problems.
 
 - Competitive compensation + early equity.
 

--- a/src/content/jobs/developer-relations-marketing-lead.md
+++ b/src/content/jobs/developer-relations-marketing-lead.md
@@ -6,7 +6,7 @@ type: 'Full-time or contract'
 equity: true
 ---
 
-### The problem
+### Overview
 
 Shorebird is building “the Flutter company”. Our founder started/led Flutter,
 and now we’re building a company to drive Flutter forward, even if Google

--- a/src/content/jobs/full-stack-software-engineer.md
+++ b/src/content/jobs/full-stack-software-engineer.md
@@ -1,8 +1,8 @@
 ---
 title: Full Stack Software Engineer
 description:
-  Build and maintain backend infrastructure that powers developer tools used in
-  production apps.
+  Build and maintain developer tools and cloud infrastructure used developers
+  around the globe.
 location:
   Remote (North America) or in-person (Chicago, New York City, or Palo Alto)
 type: Full-time
@@ -13,8 +13,8 @@ equity: true
 
 We have one successful product with thousands of monthly users, delivering 10s
 of millions of updates around the globe, every month. We built this all with 2
-engineers. We also recently launched a second product. We simply need more
-engineers to keep up with our growing user base an ambition.
+engineers. We also recently launched a second product which is also growing. We
+simply need more engineers to keep up with our growing user base an ambition.
 
 ### What You’ll Do
 

--- a/src/content/jobs/full-stack-software-engineer.md
+++ b/src/content/jobs/full-stack-software-engineer.md
@@ -9,7 +9,7 @@ type: 'Full-time'
 equity: true
 ---
 
-### The problem
+### Overview
 
 We have one successful product with thousands of monthly users, delivering 10s
 of millions of updates around the globe, every month. We built this all with 2

--- a/src/content/jobs/full-stack-software-engineer.md
+++ b/src/content/jobs/full-stack-software-engineer.md
@@ -1,7 +1,10 @@
 ---
 title: 'Full Stack Software Engineer'
-description: 'Build and maintain backend infrastructure that powers developer tools used in production apps.'
-location: 'Remote (North America) or in-person (Chicago, New York City, or Palo Alto)'
+description:
+  'Build and maintain backend infrastructure that powers developer tools used in
+  production apps.'
+location:
+  'Remote (North America) or in-person (Chicago, New York City, or Palo Alto)'
 type: 'Full-time'
 equity: true
 ---

--- a/src/content/jobs/full-stack-software-engineer.md
+++ b/src/content/jobs/full-stack-software-engineer.md
@@ -1,0 +1,60 @@
+---
+title: 'Full Stack Software Engineer'
+description: 'Build and maintain backend infrastructure that powers developer tools used in production apps.'
+location: 'Remote (North America) or in-person (Chicago, New York City, or Palo Alto)'
+type: 'Full-time'
+equity: true
+---
+
+### The problem
+
+We have one successful product with thousands of monthly users, delivering 10s
+of millions of updates around the globe, every month. We built this all with 2
+engineers. We also recently launched a second product. We simply need more
+engineers to keep up with our growing user base an ambition.
+
+### What You’ll Do
+
+- Build and maintain backend infrastructure (mostly in Dart) that powers
+  developer tools used in production apps.
+
+- Contribute to our open source command line tools and native C++ code.
+
+- Own and ship features end-to-end, from our web UI to our backend APIs.
+
+- Help shape our culture, processes, and product direction.
+
+### What We’re Looking For
+
+- Mission alignment. You care about helping the world stop writing everything
+  twice. Flutter is our tool for that and Shorebird aims to take Flutter beyond
+  where Google can.
+
+- Strong desire to work at a startup. We’re a tiny team. All remote. You’ll have
+  to want to make your own decisions and own them.
+
+- You're a strong generalist who can jump into unfamiliar systems and figure
+  things out.
+
+- You're a self-starter — you work well with little oversight and thrive in
+  ambiguous environments.
+
+- You’re excited about Flutter and want to help it succeed.
+
+- You care about product quality and developer experience.
+
+- You have solid experience with at least one part of the stack — cloud,
+  developer tools, or compilers/runtimes — and are eager to learn the rest.
+
+- Bonus: experience with build systems, deployment pipelines, or developer
+  tools.
+
+- Bonus: startup experience or contributions to open source projects.
+
+### Why Join
+
+- Work directly with a small, senior team solving hard, high-impact problems.
+
+- Competitive compensation + early equity.
+
+- Shape the future of how mobile apps are built and shipped.

--- a/src/content/jobs/full-stack-software-engineer.md
+++ b/src/content/jobs/full-stack-software-engineer.md
@@ -1,11 +1,11 @@
 ---
-title: 'Full Stack Software Engineer'
+title: Full Stack Software Engineer
 description:
-  'Build and maintain backend infrastructure that powers developer tools used in
-  production apps.'
+  Build and maintain backend infrastructure that powers developer tools used in
+  production apps.
 location:
-  'Remote (North America) or in-person (Chicago, New York City, or Palo Alto)'
-type: 'Full-time'
+  Remote (North America) or in-person (Chicago, New York City, or Palo Alto)
+type: Full-time
 equity: true
 ---
 

--- a/src/content/jobs/full-stack-software-engineer.md
+++ b/src/content/jobs/full-stack-software-engineer.md
@@ -6,7 +6,6 @@ description:
 location:
   Remote (North America) or in-person (Chicago, New York City, or Palo Alto)
 type: Full-time
-equity: true
 ---
 
 ### Overview

--- a/src/content/jobs/marketing-lead.md
+++ b/src/content/jobs/marketing-lead.md
@@ -1,8 +1,8 @@
 ---
-title: 'Marketing Lead'
-description: 'Help us reach all Flutter developers.'
-location: 'Remote (North America)'
-type: 'Full-time or contract'
+title: Marketing Lead
+description: Help us reach all Flutter developers.
+location: Remote (North America)
+type: Full-time or contract
 equity: true
 ---
 

--- a/src/content/jobs/marketing-lead.md
+++ b/src/content/jobs/marketing-lead.md
@@ -3,7 +3,6 @@ title: Marketing Lead
 description: Help us reach all Flutter developers.
 location: Remote (North America)
 type: Full-time or contract
-equity: true
 ---
 
 ### Overview

--- a/src/content/jobs/marketing-lead.md
+++ b/src/content/jobs/marketing-lead.md
@@ -1,5 +1,5 @@
 ---
-title: 'Developer Relations / Marketing Lead'
+title: 'Marketing Lead'
 description: 'Help us reach all Flutter developers.'
 location: 'Remote (North America)'
 type: 'Full-time or contract'

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -1,82 +1,44 @@
 ---
-import '@/styles/global.css';
+import MainLayout from '@/layouts/main.astro';
 import { Navbar } from '@/components/ui/navbar';
 import Footer from '@/components/ui/footer.astro';
 
 const { title, description } = Astro.props;
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <meta name="generator" content={Astro.generator} />
-
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="canonical" href={canonicalUrl} />
-    <link rel="sitemap" href="/sitemap-index.xml" />
-
-    <title>{title}</title>
-    <meta name="description" content={description} />
-
-    <!-- Open Graph Meta Tags -->
-    <meta property="og:url" content={canonicalUrl} />
-    <meta property="og:type" content="article" />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta name="description" property="og:description" content={description} />
-
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta property="twitter:domain" content="shorebird.dev" />
-    <meta property="twitter:url" content={canonicalUrl} />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
-    <meta name="twitter:site" content="@shorebirddev" />
-
-    <!-- Analytics -->
-    <script
-      defer
-      data-domain="shorebird.dev"
-      src="https://plausible.io/js/script.js"></script>
-  </head>
-  <body>
-    <Navbar client:load />
-    <article
-      class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
-    >
-      <h1 class="m-0! text-center">{title}</h1>
-      <div class="py-8 text-center">
-        <p>
-          See <a href="https://handbook.shorebird.dev/"
-            >Shorebird's Public Handbook</a
-          > to learn more about us. Shorebird is a default-public company, so nearly
-          everything is open. You're always welcome to lurk on our <a
-            href="https://discord.gg/shorebird">Discord</a
-          >, read our <a href="https://github.com/shorebirdtech"
-            >GitHub issues/code/project plans</a
-          >, and <a href="https://handbook.shorebird.dev/"
-            >public company handbook</a
-          >.
-        </p>
-      </div>
-      <slot />
-      <div class="py-8 text-center">
-        <p>
-          To apply, please email <a href="mailto:eric@shorebird.dev"
-            >eric@shorebird.dev</a
-          >. Please include your resume or LinkedIn profile.
-        </p>
-      </div>
-    </article>
-    <Footer />
-    <style is:global>
-      .prose {
-        max-width: 80ch;
-      }
-    </style>
-  </body>
-</html>
+<MainLayout title={title} description={description}>
+  <Navbar client:load />
+  <article
+    class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
+  >
+    <h1 class="m-0! text-center">{title}</h1>
+    <div class="py-8 text-center">
+      <p>
+        See <a href="https://handbook.shorebird.dev/"
+          >Shorebird's Public Handbook</a
+        > to learn more about us. Shorebird is a default-public company, so nearly
+        everything is open. You're always welcome to lurk on our <a
+          href="https://discord.gg/shorebird">Discord</a
+        >, read our <a href="https://github.com/shorebirdtech"
+          >GitHub issues/code/project plans</a
+        >, and <a href="https://handbook.shorebird.dev/"
+          >public company handbook</a
+        >.
+      </p>
+    </div>
+    <slot />
+    <div class="py-8 text-center">
+      <p>
+        To apply, please email <a href="mailto:eric@shorebird.dev"
+          >eric@shorebird.dev</a
+        >. Please include your resume or LinkedIn profile.
+      </p>
+    </div>
+  </article>
+  <Footer />
+  <style is:global>
+    .prose {
+      max-width: 80ch;
+    }
+  </style>
+</MainLayout>

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -1,0 +1,73 @@
+---
+import '@/styles/global.css';
+import { Navbar } from '@/components/ui/navbar';
+import Footer from '@/components/ui/footer.astro';
+
+const { title, description } = Astro.props;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="canonical" href={canonicalUrl} />
+    <link rel="sitemap" href="/sitemap-index.xml" />
+
+    <title>{title}</title>
+    <meta name="description" content={description} />
+
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta name="description" property="og:description" content={description} />
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="twitter:domain" content="shorebird.dev" />
+    <meta property="twitter:url" content={canonicalUrl} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:site" content="@shorebirddev" />
+
+    <!-- Analytics -->
+    <script
+      defer
+      data-domain="shorebird.dev"
+      src="https://plausible.io/js/script.js"></script>
+  </head>
+  <body>
+    <Navbar client:load />
+    <article
+      class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
+    >
+      <h1 class="m-0! text-center">{title}</h1>
+      <div class="text-center py-8">
+        <p>
+          See <a href="https://handbook.shorebird.dev/">Shorebird's Public Handbook</a> to learn more
+          about us. Shorebird is a default-public company, so nearly everything is open.
+          You're always welcome to lurk on our <a href="https://discord.gg/shorebird">Discord</a>,
+          read our <a href="https://github.com/shorebirdtech">GitHub issues/code/project plans</a>,
+          and <a href="https://handbook.shorebird.dev/">public company handbook</a>.
+        </p>
+      </div>
+      <slot />
+      <div class="text-center py-8">
+        <p>To apply, please email <a href="mailto:eric@shorebird.dev">eric@shorebird.dev</a>.</p>
+      </div>
+    </article>
+    <Footer />
+    <style is:global>
+      .prose {
+        max-width: 80ch;
+      }
+    </style>
+  </body>
+</html>

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -3,10 +3,10 @@ import MainLayout from '@/layouts/main.astro';
 import { Navbar } from '@/components/ui/navbar';
 import Footer from '@/components/ui/footer.astro';
 
-const { title, description } = Astro.props;
+const { title } = Astro.props;
 ---
 
-<MainLayout title={title} description={description}>
+<MainLayout title={title}>
   <Navbar client:load />
   <article
     class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
@@ -21,9 +21,7 @@ const { title, description } = Astro.props;
           href="https://discord.gg/shorebird">Discord</a
         >, read our <a href="https://github.com/shorebirdtech"
           >GitHub issues/code/project plans</a
-        >, and <a href="https://handbook.shorebird.dev/"
-          >public company handbook</a
-        >.
+        >, and public company handbook.
       </p>
     </div>
     <slot />

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -49,18 +49,27 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
       class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
     >
       <h1 class="m-0! text-center">{title}</h1>
-      <div class="text-center py-8">
+      <div class="py-8 text-center">
         <p>
-          See <a href="https://handbook.shorebird.dev/">Shorebird's Public Handbook</a> to learn more
-          about us. Shorebird is a default-public company, so nearly everything is open.
-          You're always welcome to lurk on our <a href="https://discord.gg/shorebird">Discord</a>,
-          read our <a href="https://github.com/shorebirdtech">GitHub issues/code/project plans</a>,
-          and <a href="https://handbook.shorebird.dev/">public company handbook</a>.
+          See <a href="https://handbook.shorebird.dev/"
+            >Shorebird's Public Handbook</a
+          > to learn more about us. Shorebird is a default-public company, so nearly
+          everything is open. You're always welcome to lurk on our <a
+            href="https://discord.gg/shorebird">Discord</a
+          >, read our <a href="https://github.com/shorebirdtech"
+            >GitHub issues/code/project plans</a
+          >, and <a href="https://handbook.shorebird.dev/"
+            >public company handbook</a
+          >.
         </p>
       </div>
       <slot />
-      <div class="text-center py-8">
-        <p>To apply, please email <a href="mailto:eric@shorebird.dev">eric@shorebird.dev</a>.</p>
+      <div class="py-8 text-center">
+        <p>
+          To apply, please email <a href="mailto:eric@shorebird.dev"
+            >eric@shorebird.dev</a
+          >. Please include your resume or LinkedIn profile.
+        </p>
       </div>
     </article>
     <Footer />

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -12,7 +12,7 @@ const { title } = Astro.props;
     class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
   >
     <h1 class="m-0! text-center">{title}</h1>
-    <div class="py-8 text-center">
+    <div class="py-8">
       <p>
         Shorebird is a default-public company, so nearly everything we do is in
         the open. You're always welcome to lurk on our <a
@@ -25,7 +25,7 @@ const { title } = Astro.props;
       </p>
     </div>
     <slot />
-    <div class="py-8 text-center">
+    <div class="py-8">
       <p>
         To apply, please email <a href="mailto:eric@shorebird.dev"
           >eric@shorebird.dev</a

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -4,7 +4,7 @@ import { Navbar } from '@/components/ui/navbar';
 import Footer from '@/components/ui/footer.astro';
 import config from '@/config';
 
-const { title } = Astro.props;
+const { title, location, type } = Astro.props;
 ---
 
 <MainLayout title={title}>
@@ -13,10 +13,6 @@ const { title } = Astro.props;
     class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
   >
     <h1 class="m-0! text-center">{title}</h1>
-    <div class="text-text-2">
-        <p>Location: {Astro.props.location}</p>
-        <p>Type: {Astro.props.type}</p>
-    </div>
     <div class="py-8">
       <p>
         Shorebird is a default-public company, so nearly everything we do is in
@@ -28,6 +24,10 @@ const { title } = Astro.props;
           >public company handbook</a
         > to see how we work.
       </p>
+    </div>
+    <div class="text-text-2">
+      <p><strong>Location:</strong> {location}</p>
+      <p><strong>Type:</strong> {type}</p>
     </div>
     <slot />
     <div class="py-8">

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -13,6 +13,9 @@ const { title } = Astro.props;
     class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
   >
     <h1 class="m-0! text-center">{title}</h1>
+    <div class="text-center text-text-2">
+        <p>{Astro.props.location} / {Astro.props.type}</p>
+    </div>
     <div class="py-8">
       <p>
         Shorebird is a default-public company, so nearly everything we do is in

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -14,14 +14,14 @@ const { title } = Astro.props;
     <h1 class="m-0! text-center">{title}</h1>
     <div class="py-8 text-center">
       <p>
-        See <a href="https://handbook.shorebird.dev/"
-          >Shorebird's Public Handbook</a
-        > to learn more about us. Shorebird is a default-public company, so nearly
-        everything is open. You're always welcome to lurk on our <a
+        Shorebird is a default-public company, so nearly everything we do is in
+        the open. You're always welcome to lurk on our <a
           href="https://discord.gg/shorebird">Discord</a
         >, read our <a href="https://github.com/shorebirdtech"
           >GitHub issues/code/project plans</a
-        >, and public company handbook.
+        >, and <a href="https://handbook.shorebird.dev/"
+          >public company handbook</a
+        > to see how we work.
       </p>
     </div>
     <slot />

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -2,6 +2,7 @@
 import MainLayout from '@/layouts/main.astro';
 import { Navbar } from '@/components/ui/navbar';
 import Footer from '@/components/ui/footer.astro';
+import config from '@/config';
 
 const { title } = Astro.props;
 ---
@@ -16,10 +17,10 @@ const { title } = Astro.props;
       <p>
         Shorebird is a default-public company, so nearly everything we do is in
         the open. You're always welcome to lurk on our <a
-          href="https://discord.gg/shorebird">Discord</a
-        >, read our <a href="https://github.com/shorebirdtech"
+          href={config.discordUrl}>Discord</a
+        >, read our <a href={config.githubUrl}
           >GitHub issues/code/project plans</a
-        >, and <a href="https://handbook.shorebird.dev/"
+        >, and <a href={config.handbookUrl}
           >public company handbook</a
         > to see how we work.
       </p>
@@ -27,8 +28,8 @@ const { title } = Astro.props;
     <slot />
     <div class="py-8">
       <p>
-        To apply, please email <a href="mailto:eric@shorebird.dev"
-          >eric@shorebird.dev</a
+        To apply, please email <a href={`mailto:${config.hiringEmail}`}
+          >{config.hiringEmail}</a
         >. Please include your resume or LinkedIn profile.
       </p>
     </div>

--- a/src/layouts/job.astro
+++ b/src/layouts/job.astro
@@ -13,8 +13,9 @@ const { title } = Astro.props;
     class="prose prose-invert mx-auto w-11/12 py-9 lg:pt-20 xl:w-10/12 2xl:w-[1280px]"
   >
     <h1 class="m-0! text-center">{title}</h1>
-    <div class="text-center text-text-2">
-        <p>{Astro.props.location} / {Astro.props.type}</p>
+    <div class="text-text-2">
+        <p>Location: {Astro.props.location}</p>
+        <p>Type: {Astro.props.type}</p>
     </div>
     <div class="py-8">
       <p>

--- a/src/pages/jobs/[...slug].astro
+++ b/src/pages/jobs/[...slug].astro
@@ -1,0 +1,19 @@
+---
+import { getCollection, render } from 'astro:content';
+import JobLayout from '@/layouts/job.astro';
+
+export async function getStaticPaths() {
+  const jobs = await getCollection('jobs');
+  return jobs.map((job) => ({
+    params: { slug: job.id },
+    props: { job },
+  }));
+}
+
+const { job } = Astro.props;
+const { Content } = await render(job);
+---
+
+<JobLayout {...job.data}>
+  <Content />
+</JobLayout>

--- a/src/pages/jobs/index.astro
+++ b/src/pages/jobs/index.astro
@@ -41,7 +41,7 @@ const jobs = (await getCollection('jobs')).filter((job) => !job.data.draft);
                     {job.data.title}
                   </h1>
                 </div>
-                <p class="text-text-2 overflow-hidden text-ellipsis whitespace-nowrap">
+                <p class="text-text-2 overflow-hidden text-ellipsis">
                   {job.data.description}
                 </p>
               </CardContent>

--- a/src/pages/jobs/index.astro
+++ b/src/pages/jobs/index.astro
@@ -1,0 +1,56 @@
+---
+import '@/styles/global.css';
+import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import { getCollection } from 'astro:content';
+import { Navbar } from '@/components/ui/navbar';
+import { ScrollToTopButton } from '@/components/scroll-to-top-button';
+import { Spacer } from '@/components/ui/spacer';
+import Footer from '@/components/ui/footer.astro';
+import MainLayout from '@/layouts/main.astro';
+
+const jobs = (await getCollection('jobs')).filter((job) => !job.data.draft);
+---
+
+<MainLayout title="Jobs">
+  <Navbar client:load />
+  <section
+    class="mx-auto flex w-10/12 flex-col items-start py-12 lg:py-24 xl:w-10/12 2xl:w-[1280px]"
+  >
+    <h1
+      class="text-text-1 mx-auto text-center text-5xl font-semibold md:mx-0 md:text-start"
+    >
+      Open <span class="gradient-text">Positions</span>
+    </h1>
+    <Spacer />
+    <div
+      class="flex w-full flex-col items-start justify-between gap-6 md:flex-row"
+    >
+      <h3 class="text-text-2 mx-auto text-center text-lg md:mx-0 md:text-start">
+        Come work with us at Shorebird.
+      </h3>
+    </div>
+    <Spacer className="h-10" />
+    <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      {
+        jobs.map((job) => (
+          <a href={`/jobs/${job.id}`} class="hover:no-underline">
+            <Card className="gap-2 py-0 cursor-pointer border-2 border-border-1 hover:border-accent-secondary-1">
+              <CardContent className="p-4">
+                <div class="flex flex-col gap-3">
+                  <h1 class="text-text-1 text-xl hover:underline">
+                    {job.data.title}
+                  </h1>
+                </div>
+                <p class="text-text-2 overflow-hidden text-ellipsis whitespace-nowrap">
+                  {job.data.description}
+                </p>
+              </CardContent>
+            </Card>
+          </a>
+        ))
+      }
+    </div>
+  </section>
+  <Footer />
+  <ScrollToTopButton client:load />
+</MainLayout>

--- a/src/pages/privacy/index.md
+++ b/src/pages/privacy/index.md
@@ -24,7 +24,6 @@ We collect the following categories of information when you use our Services:
 
 - Information you provide directly to us: Contact Information, like name and
   email address.
-
   - Sign-In Information, including your username, password, and site
     registrations.
   - Transaction and Billing Data, including your bank account and payment card


### PR DESCRIPTION
Migrates the /jobs page to a content collection, similar to /blog. Each job is now a separate file in src/content/jobs, and /jobs is a page that shows cards for each open job.
